### PR TITLE
Only allow Administrator to assign roles to users

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,9 @@
           "imports": "never",
           "exports": "never",
           "functions": "never"
+        }],
+        "no-param-reassign": ["error", {
+            "props": false
         }]
     } 
 }

--- a/app/controllers/authentication.js
+++ b/app/controllers/authentication.js
@@ -36,6 +36,7 @@ function login(req, res) {
 
     const tokenData = {
       username: userData.attributes.username,
+      is_admin: userData.attributes.is_admin,
       // todo add other token data
     };
 

--- a/app/controllers/authentication.js
+++ b/app/controllers/authentication.js
@@ -35,8 +35,7 @@ function login(req, res) {
     }
 
     const tokenData = {
-      username: userData.attributes.username,
-      is_admin: userData.attributes.is_admin,
+      userId: userData.attributes.id,
       // todo add other token data
     };
 

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -1,6 +1,30 @@
 const auth = require('../lib/authentication');
 
 /**
+ * Error handler for verifyToken errors
+ */
+function tokenErrorHandler(err, res) {
+  if (err.name === 'TokenExpiredError') {
+    return res.status(401).json({
+      error: 'TokenExpired',
+      message: 'jwt expired',
+    });
+  }
+
+  if (err.name === 'JsonWebTokenError') {
+    return res.status(401).json({
+      error: 'NoToken',
+      message: 'jwt must be provided',
+    });
+  }
+  console.log(err);
+  return res.status(401).json({
+    error: 'Unauthorized',
+    message: 'You are not authenticated.',
+  });
+}
+
+/**
  * Verify that a token is valid, thus proving that this user
  * is properly authenticated/logged in
  */
@@ -24,27 +48,31 @@ function validateAuthentication(req, res, next) {
 
   return auth.verifyToken(authMatch[1], (err) => {
     if (err) {
-      if (err.name === 'TokenExpiredError') {
-        return res.status(401).json({
-          error: 'TokenExpired',
-          message: 'jwt expired',
-        });
-      }
-
-      if (err.name === 'JsonWebTokenError') {
-        return res.status(401).json({
-          error: 'NoToken',
-          message: 'jwt must be provided',
-        });
-      }
-      console.log(err);
-      return res.status(401).json({
-        error: 'Unauthorized',
-        message: 'You are not authenticated.',
-      });
+      tokenErrorHandler(err, res);
     }
 
+    return next();
+  });
+}
 
+/**
+ * Verify the user token, and ensure that the user is an Administrator.
+ */
+function verifyAdministrator(req, res, next) {
+  const authHeader = req.get('Authorization');
+  const authMatch = authHeader.match(/Bearer (.*)$/);
+
+  // Decoded is the decoded JWT token returned upon successful verification
+  return auth.verifyToken(authMatch[1], (err, decoded) => {
+    if (err) {
+      tokenErrorHandler(err, res);
+    }
+    if (!(decoded.is_admin)) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'You must be an Administrator',
+      });
+    }
     return next();
   });
 }
@@ -52,4 +80,5 @@ function validateAuthentication(req, res, next) {
 
 module.exports = {
   validateAuthentication,
+  verifyAdministrator,
 };

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -26,8 +26,8 @@ router.delete(
 );
 router.patch(
   '/:id/roles',
-  authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
-  authenticationMiddleware.verifyAdministrator,     // verifyAdministrator middleware
+  authenticationMiddleware.validateAuthenticationAttachUser, // verify token and attach user to res
+  authenticationMiddleware.verifyAdministrator,              // verifyAdministrator middleware
   userController.setRoles
 );
 

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -26,7 +26,8 @@ router.delete(
 );
 router.patch(
   '/:id/roles',
-  authenticationMiddleware.validateAuthentication,
+  authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
+  authenticationMiddleware.verifyAdministrator,     // verifyAdministrator middleware
   userController.setRoles
 );
 

--- a/migrations/20160912145044_setup.js
+++ b/migrations/20160912145044_setup.js
@@ -32,9 +32,9 @@ exports.up = knex =>
 
 exports.down = (knex, Promise) =>
   Promise.all([
-    knex.schema.dropTable('user'),
     knex.schema.dropTable('password'),
     knex.schema.dropTable('email'),
-    knex.schema.dropTable('role'),
     knex.schema.dropTable('user_role'),
+    knex.schema.dropTable('role'),
+    knex.schema.dropTable('user'),
   ]);

--- a/seeds/seed_roles.js
+++ b/seeds/seed_roles.js
@@ -1,0 +1,15 @@
+exports.seed = knex =>
+  knex.transaction((trx) => {
+    knex('role').transacting(trx).insert({
+      id: 1,
+      name: 'Professor',
+    })
+    .then(trx.commit)
+    .catch(
+      (err) => {
+        trx.rollback();
+        console.error(err);
+        process.exit(1);
+      }
+    );
+  });

--- a/seeds/test_user.js
+++ b/seeds/test_user.js
@@ -1,0 +1,32 @@
+
+exports.seed = knex =>
+  knex.transaction((trx) => {
+    knex('user').transacting(trx).insert({
+      username: 'test_user',
+      is_admin: false,
+    }).then((results) => {
+      const userId = results[0];
+      return Promise.all([
+        knex('email').transacting(trx)
+        .insert({
+          user_id: userId,
+          address: 'test_user@test.com',
+          verified: true,
+        }),
+        knex('password').transacting(trx)
+        .insert({
+          user_id: userId,
+          password_hash: '$2a$10$cQdFPw67dAF0ICqAJSAey.zHT5whddjk.nva6YwTwXckMW04htDwG',
+          valid: true,
+        }),
+      ]);
+    })
+    .then(trx.commit)
+    .catch(
+      (err) => {
+        trx.rollback();
+        console.error(err);
+        process.exit(1);
+      }
+    );
+  });

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -6,6 +6,9 @@
     },
     "rules": {
       // Override default settings for this directory
-      "no-underscore-dangle": "off"
+      "no-underscore-dangle": "off",
+      "no-unused-vars": ["error", {
+        "varsIgnorePattern": "should"
+      }]
     }  
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -5,7 +5,6 @@
       "mocha": true
     },
     "rules": {
-      // Override default settings for this directory
       "no-underscore-dangle": "off",
       "no-unused-vars": ["error", {
         "varsIgnorePattern": "should"

--- a/test/api/test-user-login.js
+++ b/test/api/test-user-login.js
@@ -3,9 +3,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const server = require('../../app');
 
-/* eslint-disable */
 const should = chai.should();
-/* eslint-enable */
 
 chai.use(chaiHttp);
 

--- a/test/api/test-user-registration.js
+++ b/test/api/test-user-registration.js
@@ -3,9 +3,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const server = require('../../app');
 
-/* eslint-disable */
 const should = chai.should();
-/* eslint-enable */
 
 chai.use(chaiHttp);
 

--- a/test/api/test-user-role.js
+++ b/test/api/test-user-role.js
@@ -3,9 +3,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const server = require('../../app');
 
-/* eslint-disable */
 const should = chai.should();
-/* eslint-enable */
 
 chai.use(chaiHttp);
 
@@ -47,7 +45,9 @@ describe('User Role API Test', () => {
           return agent.patch('/api/user/1/roles')
             .set('Authorization', `Bearer ${res.body.token}`)
             .send({
-              add: 1,
+              add: {
+                role_id: 1,
+              },
             })
             .then((response) => {
               response.should.have.status(200);
@@ -71,7 +71,9 @@ describe('User Role API Test', () => {
           return agent.patch('/api/user/1/roles')
             .set('Authorization', `Bearer ${res.body.token}`)
             .send({
-              add: 1,
+              add: {
+                role_id: 1,
+              },
             })
             .catch((error) => {
               error.should.have.status(403);

--- a/test/api/test-user-role.js
+++ b/test/api/test-user-role.js
@@ -38,7 +38,7 @@ describe('User Role API Test', () => {
       agent
         .post('/api/login')
         .send({
-          username: 'admin',
+          username: 'test_user_admin',
           password: 'password',
         })
         .then((res) => {
@@ -51,6 +51,30 @@ describe('User Role API Test', () => {
             })
             .then((response) => {
               response.should.have.status(200);
+              done();
+            });
+        });
+    });
+    it('should fail user role update on /api/user/:id/role', (done) => {
+      const agent = chai.request.agent(server);
+
+      // login and get a token
+      agent
+        .post('/api/login')
+        .send({
+          username: 'test_user',
+          password: 'password',
+        })
+        .then((res) => {
+          res.should.have.status(200);
+          // attempt to add role 1 to user 1
+          return agent.patch('/api/user/1/roles')
+            .set('Authorization', `Bearer ${res.body.token}`)
+            .send({
+              add: 1,
+            })
+            .catch((error) => {
+              error.should.have.status(403);
               done();
             });
         });

--- a/test/api/test-user-role.js
+++ b/test/api/test-user-role.js
@@ -1,0 +1,59 @@
+const knex = require('../../app/lib/db');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../app');
+
+/* eslint-disable */
+const should = chai.should();
+/* eslint-enable */
+
+chai.use(chaiHttp);
+
+describe('User Role API Test', () => {
+  beforeEach((done) => {
+    knex.migrate.rollback()
+      .then(() => {
+        knex.migrate.latest()
+          .then(() => {
+            knex.seed.run()
+              .then(() => {
+                done();
+              });
+          });
+      });
+  });
+
+  afterEach((done) => {
+    knex.migrate.rollback()
+    .then(() => {
+      done();
+    });
+  });
+
+  describe('user role update on /api/user/:id/role', () => {
+    it('should succeed user role update on /api/user/:id/role', (done) => {
+      const agent = chai.request.agent(server);
+
+      // login and get a token
+      agent
+        .post('/api/login')
+        .send({
+          username: 'admin',
+          password: 'password',
+        })
+        .then((res) => {
+          res.should.have.status(200);
+          // attempt to add role 1 to user 1
+          return agent.patch('/api/user/1/roles')
+            .set('Authorization', `Bearer ${res.body.token}`)
+            .send({
+              add: 1,
+            })
+            .then((response) => {
+              response.should.have.status(200);
+              done();
+            });
+        });
+    });
+  });
+});

--- a/test/app/controllers/test-user-controller.js
+++ b/test/app/controllers/test-user-controller.js
@@ -3,9 +3,7 @@ const chai = require('chai');
 const UserController = require('../../../app/controllers/user');
 const MockExpressResponse = require('mock-express-response');
 
-/* eslint-disable */
 const should = chai.should();
-/* eslint-enable */
 
 // Timeout to be used for checking controller responses
 const timeout = 250;


### PR DESCRIPTION
Includes two new middleware:
* validateAuthenticationAttachUser, which attaches the user model for the requesting user on the req object.
* verifyAdministrator, which uses the req.user object attached via the above middleware to check whether the user is an admin, and 403's if they are not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andymeneely/dev-fortress-server/9)
<!-- Reviewable:end -->
