### PR TITLE
Ignore code coverage for "unreachable" code

### DIFF
--- a/app/controllers/authentication.js
+++ b/app/controllers/authentication.js
@@ -8,6 +8,7 @@ const authentication = require('../lib/authentication');
  * @param {Express.Response}  res  - the response
  */
 function refreshToken(req, res) {
+  /* istanbul ignore if */
   if (!(req.user)) {
     console.error('No user data attached to req.body. AttachUser middleware is required.');
     res.status(500).json({
@@ -70,6 +71,7 @@ function login(req, res) {
     refreshToken(req, res);
   })
   .catch((err) => {
+    /* istanbul ignore else */
     if (err.message === 'EmptyResponse') {
       res.status(400)
       .json({

--- a/app/controllers/event.js
+++ b/app/controllers/event.js
@@ -14,7 +14,10 @@ const has = require('has');
 function getEvents(req, res) {
   return Event.fetchAll()
   .then(collection => res.json(collection.serialize()))
-  .catch(err => console.error(err));
+  .catch(
+    /* istanbul ignore next */
+    err => console.error(err)
+  );
 }
 
 /**
@@ -28,21 +31,23 @@ function getEventById(req, res) {
   })
   .then(event => res.json(event.serialize()))
   .catch((err) => {
-    // 404
+    /* istanbul ignore else */
     if (err.message === 'EmptyResponse') {
-      return res.status(404)
+      // 404
+      res.status(404)
       .json({
         error: 'An Event with that ID could not be found.',
         request: { params: req.params },
       });
+    } else {
+      // Unknown error
+      console.error(err);
+      res.status(500)
+      .json({
+        error: 'UnknownError',
+        request: { params: req.params },
+      });
     }
-    // Unknown error
-    console.error(err);
-    return res.status(500)
-    .json({
-      error: 'UnknownError',
-      request: { params: req.params },
-    });
   });
 }
 
@@ -112,15 +117,17 @@ function createEvent(req, res) {
     })
   )
   .catch((err) => {
-    // name exists
+    /* istanbul ignore else */
     if (err.message === 'A event with that name already exists.') {
-      return res.status(400).json({ error: err.message });
+      // Name exists
+      res.status(400).json({ error: err.message });
+    } else {
+      console.error(err);
+      res.status(500)
+      .json({
+        error: 'UnknownError',
+      });
     }
-    console.error(err);
-    return res.status(500)
-    .json({
-      error: 'UnknownError',
-    });
   });
 }
 /**
@@ -141,13 +148,16 @@ function updateEvent(req, res) {
         .then((updatedEvent) => {
           res.status(200).json(updatedEvent);
         })
-        .catch((err) => {
-          console.error(err);
-          return res.status(500).json({
-            error: 'UnknownError',
-            request: req.body,
-          });
-        });
+        .catch(
+          /* istanbul ignore next */
+          (err) => {
+            console.error(err);
+            return res.status(500).json({
+              error: 'UnknownError',
+              request: req.body,
+            });
+          }
+        );
     });
 }
 

--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -23,13 +23,16 @@ function validateNameUnique(newName) {
 function getGames(req, res) {
   return Game.fetchAll()
   .then(collection => res.json(collection.serialize()))
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-      request: req.body,
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+        request: req.body,
+      });
+    }
+  );
 }
 
 /**
@@ -49,13 +52,16 @@ function getGameById(req, res) {
       });
     }
   })
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-      request: req.params,
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+        request: req.params,
+      });
+    }
+  );
 }
 
 /**
@@ -197,13 +203,16 @@ function updateGame(req, res) {
         res.status(200).json(updatedGame.serialize());
       })
       )
-      .catch((err) => {
-        console.error(err);
-        res.status(500).json({
-          error: 'UnknownError',
-          request: updatedFields,
-        });
-      });
+      .catch(
+        /* istanbul ignore next */
+        (err) => {
+          console.error(err);
+          res.status(500).json({
+            error: 'UnknownError',
+            request: updatedFields,
+          });
+        }
+      );
     }
   });
 
@@ -246,28 +255,32 @@ function createGame(req, res) {
         Game.where('id', game.id).fetch()
         .then(newGame => res.status(201).json(newGame.serialize()))
       )
-      .catch((err) => {
-        console.error(err);
-        return res.status(500).json({
-          error: 'UnknownError',
-          request: newGameReq,
-        });
-      });
+      .catch(
+        /* istanbul ignore next */
+        (err) => {
+          console.error(err);
+          return res.status(500).json({
+            error: 'UnknownError',
+            request: newGameReq,
+          });
+        }
+      );
     }
   })
   .catch((err) => {
+    /* istanbul ignore else */
     if (err.message === 'Game with Name exists') {
       res.status(400).json({
         error: 'There is already a Game with that name. Please choose a unique name.',
         request: newGameReq,
       });
-      return null;
+    } else {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+        request: newGameReq,
+      });
     }
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-      request: newGameReq,
-    });
     return null;
   });
 }

--- a/app/controllers/role.js
+++ b/app/controllers/role.js
@@ -14,12 +14,15 @@ const Role = require('../models/role');
 function getRoles(req, res) {
   return Role.fetchAll()
   .then(collection => res.json(collection.serialize()))
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+      });
+    }
+  );
 }
 
 /**
@@ -31,12 +34,15 @@ function getRoles(req, res) {
 function createRole(req, res) {
   return Role.forge(req.body)
   .save().then(role => res.json(role.serialize()))
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+      });
+    }
+  );
 }
 
 /**
@@ -49,12 +55,15 @@ function getRoleUsers(req, res) {
   return Role.forge({ id: req.params.id })
   .fetch({ withRelated: 'users' })
   .then(role => res.json(role.related('users')))
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+      });
+    }
+  );
 }
 
 

--- a/app/controllers/rumor.js
+++ b/app/controllers/rumor.js
@@ -50,13 +50,16 @@ function updateExistingRumor(req, res) {
         .then((updatedRumor) => {
           res.status(200).json(serializeAndCoerce(updatedRumor)[0]);
         })
-        .catch((err) => {
-          console.error(err);
-          res.status(500).json({
-            error: 'UnknownError',
-            request: req.body,
-          });
-        });
+        .catch(
+          /* istanbul ignore next */
+          (err) => {
+            console.error(err);
+            res.status(500).json({
+              error: 'UnknownError',
+              request: req.body,
+            });
+          }
+        );
     });
 }
 
@@ -71,12 +74,15 @@ function getRumors(req, res) {
     const rumors = serializeAndCoerce(collection);
     res.json(rumors);
   })
-  .catch((err) => {
-    console.error(err);
-    res.status(500).json({
-      error: 'UnknownError',
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      res.status(500).json({
+        error: 'UnknownError',
+      });
+    }
+  );
 }
 
 /**
@@ -97,13 +103,16 @@ function getRumorById(req, res) {
       res.json(rumorJson);
     }
   })
-  .catch((err) => {
-    console.error(err);
-    return res.status(500).json({
-      error: err,
-      request: req,
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      return res.status(500).json({
+        error: err,
+        request: req,
+      });
+    }
+  );
 }
 
 /**
@@ -139,50 +148,46 @@ function createRumor(req, res) {
     Rumor.forge(newRumorData)
       .save().then(rumor => res.json(serializeAndCoerce(rumor)[0]))
       .catch((err) => {
+        /* istanbul ignore else */
         if (err.errno === 19 && err.code === 'SQLITE_CONSTRAINT') {
-          return res.status(409).json({
+          res.status(409).json({
             error: err,
             request: newRumorData,
           });
+        } else {
+          console.error(err);
+          res.status(500).json({
+            error: 'UnknownError',
+            request: newRumorData,
+          });
         }
-        console.error(err);
-        return res.status(500).json({
-          error: 'UnknownError',
-          request: newRumorData,
-        });
       });
   }, (reason) => {
-    // Promise rejected.
+    /* istanbul ignore else */
     if (reason.message === 'EmptyResponse') {
-      return res.status(400).json({
+      // Promise rejected.
+      res.status(400).json({
         error: 'The Event represented by event_id does not exist.',
         request: newRumorData,
       });
-    }
-    console.error(reason);
-    return res.status(500).json({
-      error: 'UnknownError',
-      requst: newRumorData,
-    });
-  })
-  .catch((error) => {
-    console.error(error);
-  });
-  Rumor.forge(newRumorData)
-    .save().then(rumor => res.json(serializeAndCoerce(rumor)[0]))
-    .catch((err) => {
-      if (err.errno === 19 && err.code === 'SQLITE_CONSTRAINT') {
-        res.status(409).json({
-          error: err,
-          request: newRumorData,
-        });
-      }
-      console.error(err);
+    } else {
+      console.error(reason);
       res.status(500).json({
         error: 'UnknownError',
-        request: newRumorData,
+        requst: newRumorData,
       });
-    });
+    }
+  })
+  .catch(
+    /* istanbul ignore next */
+    (error) => {
+      console.error(error);
+      res.status(500).json({
+        error: 'UnknownError',
+        requst: newRumorData,
+      });
+    }
+  );
 }
 
 module.exports = {

--- a/app/controllers/teamtype.js
+++ b/app/controllers/teamtype.js
@@ -39,13 +39,16 @@ function updateExistingTeamType(req, res) {
         .then((updatedTeamType) => {
           res.status(200).json(updatedTeamType);
         })
-        .catch((err) => {
-          console.error(err);
-          return res.status(500).json({
-            error: 'UnknownError',
-            request: req.body,
-          });
-        });
+        .catch(
+          /* istanbul ignore next */
+          (err) => {
+            console.error(err);
+            return res.status(500).json({
+              error: 'UnknownError',
+              request: req.body,
+            });
+          }
+        );
     });
 }
 
@@ -60,13 +63,16 @@ function getTeamTypes(req, res) {
     const teamTypes = serializeAndCoerce(collection);
     res.json(teamTypes);
   })
-  .catch((err) => {
-    console.error(err);
-    return res.status(500).json({
-      error: 'UnknownError',
-      request: req.body,
-    });
-  });
+  .catch(
+    /* istanbul ignore next */
+    (err) => {
+      console.error(err);
+      return res.status(500).json({
+        error: 'UnknownError',
+        request: req.body,
+      });
+    }
+  );
 }
 
 /**
@@ -83,21 +89,23 @@ function getTeamTypeById(req, res) {
     res.json(teamType);
   })
   .catch((err) => {
-    // 404
+    /* istanbul ignore else */
     if (err.message === 'EmptyResponse') {
-      return res.status(404)
+      // 404
+      res.status(404)
       .json({
         error: 'A TeamType with the requested id could not be found.',
         request: { params: req.params },
       });
+    } else {
+      // Unknown error
+      console.error(err);
+      res.status(500)
+      .json({
+        error: 'UnknownError',
+        request: { params: req.params },
+      });
     }
-    // Unknown error
-    console.error(err);
-    return res.status(500)
-    .json({
-      error: 'UnknownError',
-      request: { params: req.params },
-    });
   });
 }
 
@@ -140,17 +148,19 @@ function createTeamType(req, res) {
   return TeamType.forge(req.body)
     .save().then(teamtype => res.json(teamtype.serialize()))
     .catch((err) => {
+      /* istanbul ignore else */
       if (err.errno === 19 && err.code === 'SQLITE_CONSTRAINT') {
-        return res.status(409).json({
+        res.status(409).json({
           error: err,
           request: req.body,
         });
+      } else {
+        console.error(err);
+        res.status(500).json({
+          error: 'UnknownError',
+          request: req.body,
+        });
       }
-      console.error(err);
-      return res.status(500).json({
-        error: 'UnknownError',
-        request: req.body,
-      });
     });
 }
 

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -120,20 +120,22 @@ function registerNewUser(req, res) {
     })
   )
   .catch((err) => {
-    // username exists
     if (err.message === 'A user with that username already exists.') {
-      return res.status(400).json({ error: err.message });
+      // username exists
+      res.status(400).json({ error: err.message });
     }
-    // email exists
+    /* istanbul ignore else */
     if (err.message === 'That email is already taken.') {
-      return res.status(400).json({ error: err.message });
+      // username exists
+      res.status(400).json({ error: err.message });
+    } else {
+      // Unknown error
+      console.error(err);
+      res.status(500)
+      .json({
+        error: 'UnknownError',
+      });
     }
-    // Unknown error
-    console.error(err);
-    return res.status(500)
-    .json({
-      error: 'UnknownError',
-    });
   });
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -29,6 +29,7 @@ app.use((req, res, next) => {
   next(err);
 });
 
+/* istanbul ignore next */
 if (app.get('env') === 'development') {
   // development specific functionality
   // development error handler

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -97,6 +97,7 @@ function validateAuthenticationAttachUser(req, res, next) {
  * Ensure that the user is an Administrator.
  */
 function verifyAdministrator(req, res, next) {
+  /* istanbul ignore if */
   if (!req.user) {
     console.error('validateAuthenticationAttachUser middleware is a pre-requisite of verifyAdministrator middleware.');
     return res.status(500).json({
@@ -118,6 +119,7 @@ function verifyAdministrator(req, res, next) {
  * Ensure that the user is in the 'Professor' role.
  */
 function verifyProfessor(req, res, next) {
+  /* istanbul ignore if */
   if (!req.user) {
     console.error('validateAuthenticationAttachUser middleware is a pre-requisite of verifyAdministrator middleware.');
     return res.status(500).json({

--- a/app/middleware/utils.js
+++ b/app/middleware/utils.js
@@ -14,6 +14,7 @@ function allowMethods(req, res, next) {
 }
 
 function handleOptions(req, res, next) {
+  /* istanbul ignore next */
   if (req.method === 'OPTIONS') {
     // respond with 200
     return res.send(200);
@@ -26,6 +27,7 @@ function handleOptions(req, res, next) {
  * Used for when API Endpoints are deprecated / changed.
  */
 function redirect(req, res, next) {
+  /* istanbul ignore next */
   switch (req.url) {
     case '/login':
       res.redirect(308, '/api/user/login');

--- a/config/index.js
+++ b/config/index.js
@@ -4,13 +4,16 @@ const test = require('./test');
 
 function getExports() {
   switch (process.env.NODE_ENV) {
+    /* istanbul ignore next */
     case 'production':
       // TODO: Create production configuration file
       return null;
+    /* istanbul ignore next */
     case 'development':
       return development;
     case 'test':
       return test;
+    /* istanbul ignore next */
     default:
       return null;
   }

--- a/test/tests/api/test-team-login.js
+++ b/test/tests/api/test-team-login.js
@@ -31,7 +31,6 @@ describe('Team Login API Tests', () => {
         })
         .end((err, res) => {
           res.statusCode.should.equal(200);
-          console.log(res.body.token);
           should.exist(res.body.token);
           should.not.exist(err);
           done();


### PR DESCRIPTION
This pull request adds special `istanbul ignore` comments for ignoring code coverage through instanbul. These should be used *only* when a piece of code is determined to be extremely difficult/impossible to test.

The code blocks ignored by istanbul code coverage in this PR are for `500: Internal Server Error` responses that can only be hit if the server is configured incorrectly, something we currently have no plans to test for.

The goal behind this is to get a "truer" representation of code coverage. Ignored code blocks are not included in the statistics used in code coverage reports, giving us a more accurate view of the code not being covered by tests.