### PR TITLE
Complete Team Model

### DIFF
--- a/app/controllers/authentication.js
+++ b/app/controllers/authentication.js
@@ -9,16 +9,19 @@ const authentication = require('../lib/authentication');
  */
 function refreshToken(req, res) {
   /* istanbul ignore if */
-  if (!(req.user)) {
-    console.error('No user data attached to req.body. AttachUser middleware is required.');
+  if (!(req.user) && !(req.team)) {
+    console.error('No user or team data attached to req.body. AttachUser or AttachTeam middleware is required.');
     res.status(500).json({
       error: 'Internal Server Error',
       message: 'The server is configured incorrectly.',
     });
   }
+  // Set token data specific to the team or user depending on which is attached to the request.
+  const tokenId = req.user ? req.user.id : req.team.id;
+  const tokenType = req.user ? 'USER' : 'TEAM';
   const tokenData = {
-    id: req.user.id,
-    type: req.userType,
+    id: tokenId,
+    type: tokenType,
   };
   authentication.signToken(tokenData, (err, theToken) => {
     if (err) {

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -3,25 +3,31 @@ const User = require('../models/user');
 const Team = require('../models/team');
 
 /**
+ * Internal helper function.
+ * Used to send all error messages.
+ * @param {String} statusCode - the HTTP status code to send
+ * @param {String} errorType - the error type to include in the body, e.g. 'Forbidden'
+ * @param {String} errorMessage - the personal message to include in the body
+ * @param {Express.Response} res - the response object
+ */
+function sendError(statusCode, errorType, errorMessage, res) {
+  res.status(statusCode).json({
+    error: errorType,
+    message: errorMessage,
+  });
+}
+
+/**
  * Error handler for verifyToken errors
  */
 function tokenErrorHandler(err, res) {
   if (err.name === 'TokenExpiredError') {
-    res.status(401).json({
-      error: 'TokenExpired',
-      message: 'jwt expired',
-    });
+    sendError(401, 'TokenExpired', 'jwt expired', res);
   } else if (err.name === 'JsonWebTokenError') {
-    res.status(401).json({
-      error: 'NoToken',
-      message: 'jwt must be provided',
-    });
+    sendError(401, 'NoToken', 'jwt must be provided', res);
   } else {
     console.error(err);
-    res.status(401).json({
-      error: 'Unauthorized',
-      message: 'You are not authenticated.',
-    });
+    sendError(401, 'Unauthorized', 'You are not authenticated', res);
   }
 }
 
@@ -56,78 +62,94 @@ function validateAuthentication(req, res, next) {
   });
 }
 
-function validateAuthenticationAttachUser(req, res, next) {
-  const authHeader = req.get('Authorization');
-  if (!authHeader) {
-    return res.status(401).json({
-      error: 'Unauthorized',
-      message: 'You are not authenticated.',
-    });
-  }
-
-  const authMatch = authHeader.match(/Bearer (.*)$/);
-
-  if (!authMatch) {
-    return res.status(401).json({
-      error: 'Unauthorized',
-      message: 'You are not authenticated.',
-    });
-  }
-
-  const decoded = auth.verifyToken(authMatch[1]);
-  const userId = decoded.id;
-
-  const userPromise = User.where('id', userId).fetch({
+/**
+ * Internal helper function.
+ * Attaches a given User to the request.
+ * @param {Express.Request} req - the request object
+ * @param {Express.Response} res - the response object
+ * @param {String} userId - the id of the User to attach
+ */
+function attachUser(req, res, userId, next) {
+  return User.where('id', userId).fetch({
     withRelated: ['roles'],
   })
     .then((user) => {
       req.user = user.serialize();
       req.userType = 'USER';
+      next();
     })
     .catch((fetchErr) => {
       console.error(fetchErr);
-      res.status(500).json({
-        error: 'Unknown Error',
-      });
+      sendError(500, 'Internal Server Error', 'Unknown Error', res);
     });
-
-  return userPromise.then(next);
 }
 
 /**
- * Pre-req: validateAuthenticationAttachUser
+ * Internal helper function.
+ * Attaches a given Team to the request.
+ * @param {Express.Request} req - the request object
+ * @param {Express.Response} res - the response object
+ * @param {String} userId - the id of the Team to attach
+ */
+function attachTeam(req, res, teamId, next) {
+  return Team.where('id', teamId).fetch({
+    withRelated: ['game'],
+  })
+    .then((team) => {
+      req.team = team.serialize();
+      req.userType = 'TEAM';
+      next();
+    })
+    .catch((fetchErr) => {
+      console.error(fetchErr);
+      sendError(500, 'Internal Server Error', 'Unknown Error', res);
+    });
+}
+
+function validateAuthenticationAttachEntity(req, res, next) {
+  const authHeader = req.get('Authorization');
+  if (!authHeader) return sendError(401, 'Unauthorized', 'You are not authenticated.', res);
+
+  const authMatch = authHeader.match(/Bearer (.*)$/);
+
+  if (!authMatch) return sendError(401, 'Unauthorized', 'You are not authenticated.', res);
+
+  const decoded = auth.verifyToken(authMatch[1]);
+  switch (decoded.type) {
+    case 'USER':
+      return attachUser(req, res, decoded.id, next);
+    case 'TEAM':
+      return attachTeam(req, res, decoded.id, next);
+    default:
+      return sendError(500, 'Internal Server Error', 'Invalid or missing field: "type" on jwt token', res);
+  }
+}
+
+/**
+ * Pre-req: validateAuthenticationAttachEntity
  * Ensure that the user is an Administrator.
  */
 function verifyAdministrator(req, res, next) {
   /* istanbul ignore if */
   if (!req.user || !req.userType) {
-    console.error('validateAuthenticationAttachUser middleware is a pre-requisite of verifyAdministrator middleware.');
-    return res.status(500).json({
-      error: 'Internal Server Error',
-      message: 'The server is configured incorrectly.',
-    });
+    console.error('validateAuthenticationAttachEntity middleware is a pre-requisite of verifyAdministrator middleware.');
+    return sendError(500, 'Internal Server Error', 'The server is configured incorrectly.', res);
   }
   if (!req.user.is_admin || req.userType !== 'USER') {
-    return res.status(403).json({
-      error: 'Forbidden',
-      message: 'You must be an Administrator',
-    });
+    return sendError(403, 'Forbidden', 'You must be an Administrator', res);
   }
   return next();
 }
 
 /**
- * Pre-req: validateAuthenticationAttachUser
+ * Pre-req: validateAuthenticationAttachEntity
  * Ensure that the user is in the 'Professor' role.
  */
 function verifyProfessor(req, res, next) {
   /* istanbul ignore if */
   if (!req.user || !req.userType || req.userType !== 'USER') {
-    console.error('validateAuthenticationAttachUser middleware is a pre-requisite of verifyAdministrator middleware.');
-    return res.status(500).json({
-      error: 'Internal Server Error',
-      message: 'The server is configured incorrectly.',
-    });
+    console.error('validateAuthenticationAttachEntity middleware is a pre-requisite of verifyAdministrator middleware.');
+    return sendError(500, 'Internal Server Error', 'The server is configured incorrectly.', res);
   }
   // If the user is an admin, skip Professor role checking
   if (req.user.is_admin) {
@@ -144,10 +166,7 @@ function verifyProfessor(req, res, next) {
   if (isProf) {
     return next();
   }
-  return res.status(403).json({
-    error: 'Forbidden',
-    message: 'User must be part of the \'professor\' Role to perform this action',
-  });
+  return sendError(403, 'Forbidden', 'User must be part of the \'professor\' Role to perform this action', res);
 }
 
 /**
@@ -158,20 +177,17 @@ function validateTeamAttachTeam(req, res, next) {
   Team.where('link_code', req.body.link).fetch()
     .then((team) => {
       if (team) {
-        req.user = team.serialize();
+        req.team = team.serialize();
         req.userType = 'TEAM';
         return next();
       }
-      return res.status(404).json({
-        error: 'Not Found',
-        message: 'Could not find Team associated with that link',
-      });
+      return sendError(404, 'Not Found', 'Could not find a Team associated with that link', res);
     });
 }
 
 module.exports = {
   validateAuthentication,
-  validateAuthenticationAttachUser,
+  validateAuthenticationAttachEntity,
   verifyAdministrator,
   verifyProfessor,
   validateTeamAttachTeam,

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -3,7 +3,7 @@ const bookshelf = require('../lib/bookshelf');
 require('./user');
 require('./team');
 
-const Game = bookshelf.model('game', {
+const Game = bookshelf.model('Game', {
   tableName: 'game',
   storyteller() {
     return this.hasOne('User');

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -6,10 +6,10 @@ require('./team');
 const Game = bookshelf.model('game', {
   tableName: 'game',
   storyteller() {
-    return this.hasOne('user');
+    return this.hasOne('User');
   },
   team() {
-    return this.hasMany('team');
+    return this.belongsToMany('Team');
   },
 });
 

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -5,11 +5,11 @@ require('./game');
 
 const Team = bookshelf.model('Team', {
   tableName: 'team',
-  teamType() {
-    return this.hasOne('teamtype');
+  teamtype() {
+    return this.belongsTo('TeamType');
   },
   game() {
-    return this.belongsTo('game');
+    return this.belongsTo('Game');
   },
 });
 

--- a/app/routes/event.js
+++ b/app/routes/event.js
@@ -7,7 +7,7 @@ const router = express.Router();
 // GET all events
 router.get(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   eventController.getEvents
 );
@@ -15,7 +15,7 @@ router.get(
 // GET a specific event
 router.get(
   '/:id',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   eventController.getEventById
 );
@@ -23,7 +23,7 @@ router.get(
 // CREATE a new user
 router.post(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   eventController.createEvent
 );
@@ -31,7 +31,7 @@ router.post(
 // UPDATE a specific event
 router.patch(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   eventController.updateEvent
 );

--- a/app/routes/game.js
+++ b/app/routes/game.js
@@ -14,7 +14,7 @@ router.get(
 // CREATE a new Game
 router.post(
   '/',
-  authMiddleware.validateAuthenticationAttachUser,
+  authMiddleware.validateAuthenticationAttachEntity,
   authMiddleware.verifyProfessor,
   gameController.createGame
 );
@@ -29,7 +29,7 @@ router.get(
 // PATCH Game by id
 router.patch(
   '/:id',
-  authMiddleware.validateAuthenticationAttachUser,
+  authMiddleware.validateAuthenticationAttachEntity,
   authMiddleware.verifyProfessor,
   gameController.updateGame
 );

--- a/app/routes/rumor.js
+++ b/app/routes/rumor.js
@@ -5,7 +5,7 @@ const express = require('express');
 const router = express.Router();
 
 router.use(
-  authenticationMiddleware.validateAuthenticationAttachUser
+  authenticationMiddleware.validateAuthenticationAttachEntity
 );
 
 router.get(

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -18,12 +18,13 @@ router.get(
 
 router.patch(
   '/:id',
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   teamController.updateExistingTeam
 );
 
 router.post(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   teamController.createTeam
 );

--- a/app/routes/teamtype.js
+++ b/app/routes/teamtype.js
@@ -16,13 +16,13 @@ router.get(
 );
 router.patch(
   '/:id',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   teamtypeController.updateExistingTeamType
 );
 router.post(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   teamtypeController.createTeamType
 );

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -20,7 +20,7 @@ router.get(
 // CREATE a new user
 router.post(
   '/',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyAdministrator,
   userController.registerNewUser
 );
@@ -32,7 +32,7 @@ router.delete(
 );
 router.patch(
   '/:id/roles',
-  authenticationMiddleware.validateAuthenticationAttachUser, // verify token and attach user to res
+  authenticationMiddleware.validateAuthenticationAttachEntity, // verify token and attach user to res
   authenticationMiddleware.verifyAdministrator,              // verifyAdministrator middleware
   userController.setRoles
 );
@@ -42,7 +42,7 @@ router.post(
 );
 router.post(
   '/refresh',
-  authenticationMiddleware.validateAuthenticationAttachUser,
+  authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationController.refreshToken
 );
 

--- a/migrations/20160912145044_setup.js
+++ b/migrations/20160912145044_setup.js
@@ -67,7 +67,7 @@ exports.up = knex =>
     table.boolean('mature').defaultTo(false).notNullable();
     table.integer('resources').unsigned().defaultTo(0).notNullable();
     table.integer('mindset').unsigned().defaultTo(0).notNullable();
-    table.integer('type_id').references('teamtype.id').notNullable().onDelete('CASCADE');
+    table.integer('teamtype_id').references('teamtype.id').notNullable().onDelete('CASCADE');
     table.integer('game_id').references('game.id').notNullable().onDelete('CASCADE');
     table.string('link_code').unique().notNullable();
   });

--- a/test/data/seeds/30_seed_teams.js
+++ b/test/data/seeds/30_seed_teams.js
@@ -6,7 +6,7 @@ exports.seed = (knex) => {
         mature: false,
         resources: 5,
         mindset: 10,
-        type_id: 1,
+        teamtype_id: 1,
         game_id: 1,
         link_code: '1234567',
       })
@@ -25,7 +25,7 @@ exports.seed = (knex) => {
         mature: true,
         resources: 2,
         mindset: 15,
-        type_id: 2,
+        teamtype_id: 2,
         game_id: 1,
         link_code: 'qwertyu',
       })

--- a/test/tests/api/test-team-creation.js
+++ b/test/tests/api/test-team-creation.js
@@ -90,7 +90,7 @@ describe('Team Creation API Tests', () => {
       mature: false,
       resources: 10,
       mindset: 5,
-      type_id: 1,
+      teamtype_id: 1,
       game_id: 1,
     };
   }
@@ -109,7 +109,7 @@ describe('Team Creation API Tests', () => {
           resBody.mature.should.equal(reqBody.mature);
           resBody.resources.should.equal(reqBody.resources);
           resBody.mindset.should.equal(reqBody.mindset);
-          resBody.type_id.should.equal(reqBody.type_id);
+          resBody.teamtype_id.should.equal(reqBody.teamtype_id);
           resBody.game_id.should.equal(reqBody.game_id);
           should.exist(resBody.link_code);
           resBody.link_code.should.be.a('string');
@@ -130,8 +130,8 @@ describe('Team Creation API Tests', () => {
           res.should.have.status(201);
 
           const resBody = res.body;
-          resBody.should.include.keys('name', 'mature', 'resources', 'mindset', 'type_id', 'game_id');
-          resBody.type_id.should.equal(reqBody.type_id);
+          resBody.should.include.keys('name', 'mature', 'resources', 'mindset', 'teamtype_id', 'game_id');
+          resBody.teamtype_id.should.equal(reqBody.teamtype_id);
           resBody.game_id.should.equal(reqBody.game_id);
           should.exist(resBody.link_code);
           resBody.link_code.should.be.a('string');
@@ -168,9 +168,9 @@ describe('Team Creation API Tests', () => {
           done();
         });
     });
-    it('A Professor may not create a Team with an invalid "type_id" field', (done) => {
+    it('A Professor may not create a Team with an invalid "teamtype_id" field', (done) => {
       const reqBody = getMockTeamCreateRequestBody();
-      reqBody.type_id = 100;
+      reqBody.teamtype_id = 100;
       chai.request(server)
         .post(`${API_TEAM_CREATE_URL}`)
         .set('Authorization', `Bearer ${profAuthToken}`)

--- a/test/tests/api/test-team-update.js
+++ b/test/tests/api/test-team-update.js
@@ -1,14 +1,59 @@
 const API_TEAM_UPDATE_URL = require('../../data/constants').API_TEAM_UPDATE_URL;
+const API_TEAM_LOGIN_URL = require('../../data/constants').API_TEAM_LOGIN_URL;
 const knex = require('../../../app/lib/db');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const server = require('../../../app');
 
 const should = chai.should();
+const assert = chai.assert;
 
 chai.use(chaiHttp);
 
+let teamToken = null;
+const teamIdToUpdate = 1;
+
+/**
+ * Sends PATCH request with the given requestBody. Passes error/response to callback
+ * @param {Object} requestBody - Object containing fields to be updated and their values
+ * @param {*} callback - Callback function once request returns
+ */
+function sendPatchTeamRequest(requestBody, callback) {
+  chai.request(server)
+    .patch(`${API_TEAM_UPDATE_URL}${teamIdToUpdate}`)
+    .set('Authorization', `Bearer ${teamToken}`)
+    .send(requestBody)
+    .end(callback);
+}
+
 describe('Team Update API Tests', () => {
+  before((done) => {
+    // Authenticate a Team to perform protected queries.
+    function authenticateTeam() {
+      const reqURL = `${API_TEAM_LOGIN_URL}`;
+      chai.request(server)
+        .post(reqURL)
+        .send({
+          link: '1234567',
+        })
+        .end((err, res) => {
+          if (res) {
+            teamToken = res.body.token;
+            done();
+          }
+        });
+    }
+
+    // Run initial migrations and seed db
+    knex.migrate.rollback()
+      .then(() => {
+        knex.migrate.latest()
+          .then(() => {
+            knex.seed.run()
+              .then(() => authenticateTeam());
+          });
+      });
+  });
   beforeEach((done) => {
     // Run initial migrations and seed db
     knex.migrate.rollback()
@@ -23,23 +68,76 @@ describe('Team Update API Tests', () => {
 
   describe('Success', () => {
     it('An existing Team can update their name field', (done) => {
-      const newName = 'Slow Squadron';
-      const idToUpdate = 1;
-      const reqURL = `${API_TEAM_UPDATE_URL}${idToUpdate}`;
-      chai.request(server)
-        .patch(reqURL)
-        .send({ name: newName })
-        .end((err, res) => {
-          res.statusCode.should.equal(200);
-          res.body.id.should.equal(idToUpdate);
-          res.body.name.should.equal(newName);
-          should.not.exist(err);
-          done();
-        });
+      const requestBody = { name: 'Slow Squadron' };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(200);
+        res.body.id.should.equal(teamIdToUpdate);
+        res.body.name.should.equal(requestBody.name);
+        should.not.exist(err);
+        done();
+      });
     });
   });
 
   describe('Fail', () => {
+    it('An existing Team cannot update their game_id field', (done) => {
+      const requestBody = { game_id: 1 };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
 
+    it('An existing Team cannot update their type_id field', (done) => {
+      const requestBody = { type_id: 1 };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('An existing Team cannot update their resources field', (done) => {
+      const requestBody = { resources: 1 };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('An existing Team cannot update their mindset field', (done) => {
+      const requestBody = { mindset: 1 };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('An existing Team cannot update their mature field', (done) => {
+      const requestBody = { mature: true };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('An existing Team cannot update their link_code field', (done) => {
+      const requestBody = { link_code: 'ASDFGHJ' };
+      sendPatchTeamRequest(requestBody, (err, res) => {
+        res.statusCode.should.equal(400);
+        assert.deepEqual(res.body.request, requestBody);
+        should.exist(err);
+        done();
+      });
+    });
   });
 });

--- a/test/tests/api/test-team-update.js
+++ b/test/tests/api/test-team-update.js
@@ -90,8 +90,8 @@ describe('Team Update API Tests', () => {
       });
     });
 
-    it('An existing Team cannot update their type_id field', (done) => {
-      const requestBody = { type_id: 1 };
+    it('An existing Team cannot update their teamtype_id field', (done) => {
+      const requestBody = { teamtype_id: 1 };
       sendPatchTeamRequest(requestBody, (err, res) => {
         res.statusCode.should.equal(400);
         assert.deepEqual(res.body.request, requestBody);


### PR DESCRIPTION
Closes andymeneely/dev-fortress-server#21 

This pull request makes the following changes:

- Models have been updated and fixed to allow for successful `withRelated` queries.
- `validateAuthenticationAttachUser` middleware has been renamed to `validateAuthenticationAttachEntity` and modified to be able to be used as User as well as Team auth middleware.
- When a Team is returned in a response, it now includes its associated TeamType.
- A Team may only update its `name` field. All other field changes are `400: Bad Request`.
- Teams are now attached to `req.team` instead of `req.user` for better code-readability
- The `type_id` field on the Team model has been changed to `teamtype_id` to conform to Bookshelf model standards and enhanced readability.
- User tokens now include `type: 'USER'` in the token data