### PR TITLE
Allow optional 'withRelated' query param for GET game(s)

### DIFF
--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -21,16 +21,30 @@ function validateNameUnique(newName) {
  * @param  {Express.Response}  res  - the response object
  */
 function getGames(req, res) {
-  return Game.fetchAll()
+  const fetchBody = {};
+  if (req.query) {
+    if (req.query.withRelated) fetchBody.withRelated = req.query.withRelated;
+  }
+  return Game.fetchAll(fetchBody)
   .then(collection => res.json(collection.serialize()))
   .catch(
     /* istanbul ignore next */
     (err) => {
-      console.error(err);
-      res.status(500).json({
-        error: 'UnknownError',
-        request: req.body,
-      });
+      const regMatch = err.message.match(/([a-zA-Z]*) is not defined on the model/);
+      if (regMatch) {
+        res.status(400)
+        .json({
+          error: 'InvalidRelation',
+          message: `'${regMatch[1]}' is not a valid relation on this model.`,
+        });
+      } else {
+        // Unknown error
+        console.error(err);
+        res.status(500).json({
+          error: 'UnknownError',
+          request: req.body,
+        });
+      }
     }
   );
 }
@@ -41,7 +55,11 @@ function getGames(req, res) {
  * @param {Express.Response} res  - the response object
  */
 function getGameById(req, res) {
-  return Game.where('id', req.params.id).fetch()
+  const fetchBody = {};
+  if (req.query) {
+    if (req.query.withRelated) fetchBody.withRelated = req.query.withRelated;
+  }
+  return Game.where('id', req.params.id).fetch(fetchBody)
   .then((game) => {
     if (game) {
       res.status(200).json(game.serialize());
@@ -55,11 +73,21 @@ function getGameById(req, res) {
   .catch(
     /* istanbul ignore next */
     (err) => {
-      console.error(err);
-      res.status(500).json({
-        error: 'UnknownError',
-        request: req.params,
-      });
+      const regMatch = err.message.match(/([a-zA-Z]*) is not defined on the model/);
+      if (regMatch) {
+        res.status(400)
+        .json({
+          error: 'InvalidRelation',
+          message: `'${regMatch[1]}' is not a valid relation on this model.`,
+        });
+      } else {
+        // Unknown error
+        console.error(err);
+        res.status(500).json({
+          error: 'UnknownError',
+          request: req.body,
+        });
+      }
     }
   );
 }

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -6,10 +6,10 @@ require('./team');
 const Game = bookshelf.model('Game', {
   tableName: 'game',
   storyteller() {
-    return this.hasOne('User');
+    return this.hasOne('User', 'id', 'storyteller_id');
   },
-  team() {
-    return this.belongsToMany('Team');
+  teams() {
+    return this.hasMany('Team');
   },
 });
 

--- a/test/data/constants.js
+++ b/test/data/constants.js
@@ -8,6 +8,8 @@ const API_TEAM_GET_TEAMS_URL = '/api/team';
 const API_TEAM_CREATE_URL = '/api/team';
 const API_TEAM_LOGIN_URL = '/api/team/login/';
 
+const API_GAME_GET_GAME_BY_ID_URL = '/api/game/';
+const API_GAME_GET_GAMES_URL = '/api/game';
 
 // Milliseconds – How long each test should wait before checking response values.
 const TIMEOUT = 25;
@@ -21,5 +23,7 @@ module.exports = {
   API_TEAM_GET_TEAMS_URL,
   API_TEAM_CREATE_URL,
   API_TEAM_LOGIN_URL,
+  API_GAME_GET_GAME_BY_ID_URL,
+  API_GAME_GET_GAMES_URL,
   TIMEOUT,
 };

--- a/test/tests/api/test-game-retrieval.js
+++ b/test/tests/api/test-game-retrieval.js
@@ -1,0 +1,79 @@
+const API_USER_LOGIN_URL = require('../../data/constants').API_USER_LOGIN_URL;
+const API_GAME_GET_GAME_BY_ID_URL = require('../../data/constants').API_GAME_GET_GAME_BY_ID_URL;
+const API_GAME_GET_GAMES_URL = require('../../data/constants').API_GAME_GET_GAMES_URL;
+
+const knex = require('../../../app/lib/db');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../../app');
+
+const should = chai.should();
+
+chai.use(chaiHttp);
+let userToken = null;
+
+describe('Game Retrieval API Tests', () => {
+  before((done) => {
+    // Get and set valid auth token for user requests
+    function getUserToken() {
+      chai.request(server)
+          .post(`${API_USER_LOGIN_URL}`)
+          .send({
+            username: 'test_user_professor',
+            password: 'password',
+          })
+          .end((err, res) => {
+            userToken = res.body.token;
+            done();
+          });
+    }
+
+    // Run initial migrations and seed db
+    knex.migrate.rollback()
+      .then(() => {
+        knex.migrate.latest()
+          .then(() => {
+            knex.seed.run()
+              .then(() => getUserToken());
+          });
+      });
+  });
+
+  describe('Success', () => {
+    it('A Game can be retrieved withRelated teams, storyteller', (done) => {
+      const gameId = 1;
+      chai.request(server)
+          .get(`${API_GAME_GET_GAME_BY_ID_URL}${gameId}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .query({ withRelated: ['teams', 'storyteller'] })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.statusCode.should.equal(200);
+            res.body.id.should.equal(gameId);
+            res.body.teams.should.be.an('array');
+            res.body.storyteller_id.should.equal(res.body.storyteller.id);
+            done();
+          });
+    });
+    it('All Games can be retrieved withRelated teams, storyteller', (done) => {
+      chai.request(server)
+          .get(`${API_GAME_GET_GAMES_URL}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .query({ withRelated: ['teams', 'storyteller'] })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.statusCode.should.equal(200);
+            res.body.should.be.an('array');
+            // check first game for teams and storyteller
+            res.body[0].teams.should.be.an('array');
+            res.body[0].storyteller_id.should.equal(res.body[0].storyteller.id);
+            done();
+          });
+    });
+  });
+
+
+  describe('Fail', () => {
+
+  });
+});


### PR DESCRIPTION
fixes #45 

Client may specify `teams` and/or `storyteller` to retrieve related joins.

Example requests:

GET GAME BY ID
* GET `/api/game/1?withRelated=teams`
* GET `/api/game/1?withRelated=teams&withRelated=storyteller`

GET ALL GAMES
* GET `/api/game?withRelated=teams`
* GET `/api/game?withRelated=teams&withRelated=storyteller`