### PR TITLE
Return "created_at" attributes as ISOStrings

### DIFF
--- a/app/models/game.js
+++ b/app/models/game.js
@@ -5,6 +5,14 @@ require('./team');
 
 const Game = bookshelf.model('Game', {
   tableName: 'game',
+  hasTimestamps: ['created_at'],
+  parse: (attributes) => {
+    if (attributes.created_at) {
+      const createdDate = new Date(attributes.created_at);
+      attributes.created_at = createdDate.toISOString();
+    }
+    return attributes;
+  },
   storyteller() {
     return this.hasOne('User');
   },

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -6,6 +6,14 @@ require('./role');
 
 const User = bookshelf.model('User', {
   tableName: 'user',
+  hasTimestamps: ['created_at'],
+  parse: (attributes) => {
+    if (attributes.created_at) {
+      const createdDate = new Date(attributes.created_at);
+      attributes.created_at = createdDate.toISOString();
+    }
+    return attributes;
+  },
   password() {
     return this.hasOne('Password');
   },


### PR DESCRIPTION
Fixes #34 

This PR adds a custom attribute parser to the bookshelf `User` and `Game` model which returns an ISO compliant string for the `created_at` attributes.

The parse function is run before the `toJSON` method that is called when `.fetch()`ing a model. This does not affect the data stored in the DB, only how it is returned when querying from it. 