### PR TITLE
Issue 28 bug empty game name

### DIFF
--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -241,6 +241,14 @@ function createGame(req, res) {
     });
     return null;
   }
+  // Don't allow empty or all whitespace names
+  if (newGameReq.name.replace(/\s/g, '') === '') {
+    res.status(400).json({
+      error: '"name" field cannot be an empty string.',
+      request: newGameReq,
+    });
+    return null;
+  }
 
   return validateNameUnique(newGameReq.name).then((isValid) => {
     if (!isValid) {

--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -134,7 +134,7 @@ function updateGame(req, res) {
           error: '"name" field cannot be an empty string.',
           request: updatedFields,
         });
-        return null;
+        return false;
       }
       const namePromise = validateNameUnique(updatedFields.name).then((isValid) => {
         if (!isValid) {

--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -128,6 +128,14 @@ function updateGame(req, res) {
     }
 
     if (has(updatedFields, 'name')) {
+      // Don't allow empty or all whitespace names
+      if (updatedFields.name.replace(/\s/g, '') === '') {
+        res.status(400).json({
+          error: '"name" field cannot be an empty string.',
+          request: updatedFields,
+        });
+        return null;
+      }
       const namePromise = validateNameUnique(updatedFields.name).then((isValid) => {
         if (!isValid) {
           throw new Error('Game with Name exists');

--- a/test/tests/app/controllers/test-game-controller.js
+++ b/test/tests/app/controllers/test-game-controller.js
@@ -160,6 +160,20 @@ describe('Game Controller Tests', () => {
       }, timeout);
     });
 
+    it('Professor attempts to create a game with the empty string as a name.', (done) => {
+      const mockReq = getMockNewGameReq();
+      mockReq.body.name = '';
+      const mockRes = new MockExpressResponse();
+      GameController.createGame(mockReq, mockRes);
+      setTimeout(() => {
+        mockRes.statusCode.should.equal(400);
+        const resJSON = mockRes._getJSON();
+        resJSON.error.should.equal('"name" field cannot be an empty string.');
+        assert.deepEqual(resJSON.request, mockReq.body);
+        done();
+      }, timeout);
+    });
+
     it('Professor attempts to create a game without a max_round.', (done) => {
       const mockReq = getMockNewGameReq();
       delete mockReq.body.max_round;


### PR DESCRIPTION
Fixes #28 

Don't allow Games to be created/updated with the "name" field as the empty string or all whitespace characters.

_Note:_ The regex `/\s/g` finds all whitespace characters in the string.
A whitespace character can be:
* A space character
* A tab character
* A carriage return character
* A new line character
* A vertical tab character
* A form feed character