### PR TITLE
Add initial API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 logs
 *.log
 
+# API Docs
+doc/**/*
+
 # Runtime data
 pids
 *.pid

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Migrations are written in the `migrations/` directory.
 
 Once this is done you should now have a `databse.sqlite3` file in your project root. This is your project's development database.
 
+API Documentation
+----
+API documentation is generated using [apidoc](http://apidocjs.com/).
+
+`npm run apidocs`
+
+The generated documentation outputs to `doc/index.html`
+
 Project Structure
 ----
 There are numbers subdirectories within the start kit application structure.

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -5,41 +5,134 @@ const express = require('express');
 
 const router = express.Router();
 
-// GET all users
+/**
+ * @api {get} /user Get Users
+ * @apiName GetUsers
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Retrieve all Users. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {Object[]}   users             List of Users.
+ * @apiSuccess {Number}     users.id          Primary key.
+ * @apiSuccess {String}     users.username    Username; unique.
+ * @apiSuccess {Boolean}    users.is_admin    Indicates whether or not the User is an Administrator.
+ * @apiSuccess {String}     users.created_at  ISO String timestamp of when the User was created.
+ */
 router.get(
   '/',  // route
   authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
   userController.getUsers  // the controller
 );
-// GET a specific user
+
+/**
+ * @api {get} /user/:id Get User by ID
+ * @apiName GetUser
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Retrieve a User by ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}     id          User's primary key
+ *
+ * @apiSuccess {Number}     id          Primary key.
+ * @apiSuccess {String}     username    Username; unique.
+ * @apiSuccess {Boolean}    is_admin    Indicates whether or not the User is an Administrator.
+ * @apiSuccess {String}     created_at  ISO String timestamp of when the User was created.
+ */
 router.get(
   '/:id',
   authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
   userController.getUserById
 );
-// CREATE a new user
+
+/**
+ * @api {post} /user Create New User
+ * @apiName CreateUser
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Create a new User. Requires Administrator authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam {String}   username    Unique username for the User.
+ * @apiParam {String}   password    Password for the User.
+ * @apiParam {String}   email       Unique email address of the User.
+ * @apiParam {Boolean}  [is_admin]  Set `true` for Admin account.
+ *
+ * @apiSuccess {Integer}  id        Primary key of the new User.
+ * @apiSuccess {String}   username  Username of the new User.
+ */
 router.post(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyAdministrator,
   userController.registerNewUser
 );
+
 // DELETE a user
 router.delete(
   '/:id',
   authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
   userController.deleteUserById
 );
+
+/**
+ * @api {patch} /user/:id/roles Set User Role
+ * @apiName AttachUserRole
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Attach an existing User to a Role. Requires Administrator authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam {String}   :id         Primary key for the existing User.
+ * @apiParam {Integer}  [add]       The Role ID to add the User to.
+ * @apiParam {Integer}  [remove]    The Role ID to remove the User from.
+ */
 router.patch(
   '/:id/roles',
   authenticationMiddleware.validateAuthenticationAttachEntity, // verify token and attach user to res
   authenticationMiddleware.verifyAdministrator,              // verifyAdministrator middleware
   userController.setRoles
 );
+
+/**
+ * @api {post} /user/login Login to User Account
+ * @apiName UserLogin
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Login to an existing User account.
+ *
+ * @apiParam {String}   username    The username for the User.
+ * @apiParam {String}   password    The password for the User.
+ *
+ * @apiSuccess {String} token   The JWT token with which to send authenticated requests.
+ */
 router.post(
   '/login',
   authenticationController.login
 );
+
+/**
+ * @api {post} /user/refresh Refresh JWT Token
+ * @apiName UserRefreshToken
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Refresh the JWT token of the User making the request. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {String}     token             A new JWT token with which to send authenticated requests.
+ */
 router.post(
   '/refresh',
   authenticationMiddleware.validateAuthenticationAttachEntity,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
   },
   "apidoc": {
     "title": "Dev-Fortress Server",
-    "url" : "http://localhost:3000/api"
+    "url" : "http://localhost:3000/api",
+    "template": {
+      "withCompare": false
+    }
   },
   "dependencies": {
     "apidoc": "^0.17.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "express-mvc-starter",
-  "version": "0.0.0",
+  "name": "dev-fortress-server",
+  "version": "0.1.0",
+  "description": "The API for the Dev-Fortress security game.",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=development node ./bin/www",
@@ -10,9 +11,15 @@
     "exec": "exec",
     "migrate": "knex migrate:latest",
     "seed": "knex seed:run",
-    "lint": "eslint ./app;  exit 0"
+    "lint": "eslint ./app;  exit 0",
+    "apidocs": "apidoc -i app/routes"
+  },
+  "apidoc": {
+    "title": "Dev-Fortress Server",
+    "url" : "http://localhost:3000/api"
   },
   "dependencies": {
+    "apidoc": "^0.17.5",
     "bcrypt": "^0.8.7",
     "body-parser": "~1.15.1",
     "bookshelf": "^0.10.0",


### PR DESCRIPTION
This pull request adds the `api-docs` npm package and includes initial API documentation for the `/api/user` endpoints. I currently have the generated output ignored, but if we decide to continue moving on this, we can set it up on GitHub pages or something...

To test/run:
1. `npm install`
2. `npm run apidocs`
3. `open ./doc/index.html`
