### PR TITLE
Filter GET Games request by storyteller_id

### DIFF
--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -22,10 +22,14 @@ function validateNameUnique(newName) {
  */
 function getGames(req, res) {
   const fetchBody = {};
+  let knexQuery = Game;
   if (req.query) {
+    // Optional model relations
     if (req.query.withRelated) fetchBody.withRelated = req.query.withRelated;
+    // Filter by storyteller_id
+    if (req.query.storyteller_id) knexQuery = knexQuery.where('storyteller_id', req.query.storyteller_id);
   }
-  return Game.fetchAll(fetchBody)
+  return knexQuery.fetchAll(fetchBody)
   .then(collection => res.json(collection.serialize()))
   .catch(
     /* istanbul ignore next */

--- a/app/routes/game.js
+++ b/app/routes/game.js
@@ -4,7 +4,36 @@ const express = require('express');
 
 const router = express.Router();
 
-// GET all Games
+/**
+ * @api {get} /game Get All Games
+ * @apiName GetGames
+ * @apiGroup Game
+ *
+ * @apiDescription
+ * Retrieve all Games. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {String}     [withRelated]     Specify which relations
+ *                                              the Games should be returned with.
+ *                                              Valid options include: 'storyteller' and 'teams'.
+ *                                              One relation per 'withRelated' query param.
+ *
+ * @apiParam   {Integer}    [storyteller_id]  Filter Games matching the storyteller_id.
+ *
+ * @apiSuccess {Game[]}     games                 List of Games.
+ * @apiSuccess {Integer}    games.id              Primary key of the Game.
+ * @apiSuccess {String}     games.name            Custom name of the Game.
+ * @apiSuccess {String}     games.created_at      ISO String timestamp of when the Game was created.
+ * @apiSuccess {Integer}    games.current_round   The current round of the Game.
+ * @apiSuccess {Integer}    games.max_round       The round at which the Game will end.
+ * @apiSuccess {Integer}    games.round_phase     The current round phase the Game is in.
+ *                                                  Dictates what actions can take place.
+ * @apiSuccess {Integer}    games.storyteller_id  The foreign key reference to the
+ *                                                  Professor User running the Game session.
+ * @apiSuccess {User}       [games.storyteller]   The User object representing the Storyteller.
+ *                                                  Only returned when 'withRelated' == 'storyteller'.
+ */
 router.get(
   '/',
   authMiddleware.validateAuthentication,
@@ -19,7 +48,33 @@ router.post(
   gameController.createGame
 );
 
-// GET Game by id
+/**
+ * @api {get} /game Get Game by ID
+ * @apiName GetGame
+ * @apiGroup Game
+ *
+ * @apiDescription
+ * Retrieve Game by ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {String}     [withRelated]     Specify which relations
+ *                                              the Games should be returned with.
+ *                                              Valid options include: 'storyteller' and 'teams'.
+ *                                              One relation per 'withRelated' query param.
+ *
+ * @apiSuccess {Integer}    id                Primary key.
+ * @apiSuccess {String}     name              Custom name of the Game.
+ * @apiSuccess {String}     created_at        ISO String timestamp of when the Game was created.
+ * @apiSuccess {Integer}    current_round     The current round of the Game
+ * @apiSuccess {Integer}    max_round         The round at which the Game will end.
+ * @apiSuccess {Integer}    round_phase       The current round phase the Game is in.
+ *                                              Dictates what actions can take place.
+ * @apiSuccess {Integer}    storyteller_id    The foreign key reference to the
+ *                                              Professor user running the Game session.
+ * @apiSuccess {User}       [storyteller]     The User object representing the Storyteller.
+ *                                              Only returned when 'withRelated' == 'storyteller'.
+ */
 router.get(
   '/:id',
   authMiddleware.validateAuthentication,

--- a/test/tests/api/test-game-retrieval.js
+++ b/test/tests/api/test-game-retrieval.js
@@ -70,10 +70,37 @@ describe('Game Retrieval API Tests', () => {
             done();
           });
     });
+    it('All Games can be retrieved given a valid storyteller id', (done) => {
+      const storytellerId = 1;
+      chai.request(server)
+          .get(`${API_GAME_GET_GAMES_URL}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .query({ storyteller_id: storytellerId })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.statusCode.should.equal(200);
+            res.body.should.be.an('array');
+            res.body.length.should.equal(1);
+            done();
+          });
+    });
   });
 
 
   describe('Fail', () => {
-
+    it('No Games can be retrieved given an invalid storyteller id', (done) => {
+      const storytellerId = 100;
+      chai.request(server)
+          .get(`${API_GAME_GET_GAMES_URL}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .query({ storyteller_id: storytellerId })
+          .end((err, res) => {
+            should.not.exist(err);
+            res.statusCode.should.equal(200);
+            res.body.should.be.an('array');
+            res.body.length.should.equal(0);
+            done();
+          });
+    });
   });
 });


### PR DESCRIPTION
Closes #54.

## Description
This PR adds the ability to optionally filter the response of a "get all games" request by a specific `storyteller_id`.

Includes:
* `api-docs` decorators for `GET Game` requests.
* 2 additional Game API tests for the `storyteller_id` query param.

## Examples
* Retrieve all Games.
  * `GET /api/game`
* Retrieve all Games for which `User.id = 1` is the `storyteller_id` attribute.
  * `GET /api/game?storyteller_id=1`

## Code coverage for Game controller
Before | After
--- | ---
75.47% | 76.15%