### PR TITLE
Teams can select or deselect pending actions for a round

### DIFF
--- a/app/socket/controllers/game.js
+++ b/app/socket/controllers/game.js
@@ -56,6 +56,7 @@ function getGameById(gameId, callback) {
 
 // function for Storyteller to advance a Round
 function nextRound(gameId, callback) {
+  redis.set(`game_${gameId}_pending_actions`, JSON.stringify({}));
   Game.where('id', gameId).fetch().then((game) => {
     const newRound = game.attributes.current_round + 1;
     new Game({ id: gameId }).save({

--- a/app/socket/controllers/team.js
+++ b/app/socket/controllers/team.js
@@ -4,13 +4,23 @@
 const redis = require('../../redis');
 const Team = require('../../models/team');
 const roomController = require('./room');
+const emitters = require('../emitters');
+
+/**
+ * Retrieve the id of a Team associated with the requesting socket.
+ * @param {Socket.io} socket   the client socket of the Team
+ * @param {Function}  callback the function to forward the response to
+ */
+function getTeamId(socket, callback) {
+  redis.get(socket.id).then(callback);
+}
 
 /**
  * Update Redis store with Team info.
  * @param {Integer} teamId the id of the Team
  */
 function updateTeamInfo(socket, callback) {
-  redis.get(socket.id).then((teamId) => {
+  getTeamId(socket, (teamId) => {
     Team.where('id', teamId).fetch({ withRelated: ['teamtype'] })
       .then((team) => {
         const jsonString = JSON.stringify(team.serialize());
@@ -25,10 +35,9 @@ function updateTeamInfo(socket, callback) {
  * @param {Function} callback the callback
  */
 function getTeamJSON(socket, callback) {
-  redis.get(socket.id).then((teamId) => {
+  getTeamId(socket, (teamId) => {
     redis.get(`team_${teamId}`).then((team) => {
       const teamJSON = JSON.parse(team);
-      console.log(teamJSON);
       callback(teamJSON);
     });
   });
@@ -56,9 +65,49 @@ function joinGameRoom(socket, callback) {
   });
 }
 
+/**
+ * Add or remove a pending actions to redis cache.
+ * @param {Socket.io} socket     the client socket
+ * @param {Integer}   actionId   the id of the action the team is selecting
+ * @param {String}    updateType the type of update to perform: 'add' or 'remove'
+ * @param {Function}  callback   the function to call when complete
+ */
+function updatePendingTeamAction(socket, actionId, updateType, callback) {
+  if (updateType === 'remove' || updateType === 'add') {
+    getTeamJSON(socket, (team) => {
+      // Retrieve pending Game actions from cache
+      redis.get(`game_${team.game_id}_pending_actions`).then((jsonString) => {
+        let pendingActions = {};
+        let teamPendingActions = [];
+        let locationIndex = -1;
+        if (jsonString) {
+          pendingActions = JSON.parse(jsonString);
+          teamPendingActions = pendingActions[team.id];
+          if (teamPendingActions === undefined) teamPendingActions = [];
+          locationIndex = teamPendingActions.indexOf(actionId);
+        }
+        // Add or remove the action
+        if (locationIndex === -1 && updateType === 'add') teamPendingActions.push(actionId);
+        if (locationIndex !== -1 && updateType === 'remove') teamPendingActions.splice(locationIndex, 1);
+
+        // Update redis cache, emit updates
+        pendingActions[team.id] = teamPendingActions;
+        const newPendingActionsJSON = JSON.stringify(pendingActions);
+        redis.set(`game_${team.game_id}_pending_actions`, newPendingActionsJSON).then(() => {
+          console.log(`game_${team.game_id}_pending_actions`);
+          emitters.gameEmitters.emitPendingActionsUpdate(team.game_id, pendingActions);
+          callback();
+        });
+      });
+    });
+  }
+}
+
 module.exports = {
+  getTeamId,
   updateTeamInfo,
   storeSocketIdTeamId,
   getTeamJSON,
   joinGameRoom,
+  updatePendingTeamAction,
 };

--- a/app/socket/controllers/team.js
+++ b/app/socket/controllers/team.js
@@ -94,7 +94,6 @@ function updatePendingTeamAction(socket, actionId, updateType, callback) {
         pendingActions[team.id] = teamPendingActions;
         const newPendingActionsJSON = JSON.stringify(pendingActions);
         redis.set(`game_${team.game_id}_pending_actions`, newPendingActionsJSON).then(() => {
-          console.log(`game_${team.game_id}_pending_actions`);
           emitters.gameEmitters.emitPendingActionsUpdate(team.game_id, pendingActions);
           callback();
         });

--- a/app/socket/emitters/game.js
+++ b/app/socket/emitters/game.js
@@ -11,6 +11,11 @@ function emitGameUpdate(game) {
   generalEmitters.emitToRoom(`game_${game.id}`, 'game_info', game);
 }
 
+function emitPendingActionsUpdate(gameId, pendingActions) {
+  generalEmitters.emitToRoom(`game_${gameId}`, 'selected_actions_update', pendingActions);
+}
+
 module.exports = {
   emitGameUpdate,
+  emitPendingActionsUpdate,
 };

--- a/app/socket/handlers/handlers.js
+++ b/app/socket/handlers/handlers.js
@@ -11,8 +11,35 @@ const storytellerController = require('../controllers/storyteller');
  * @param socket the socket to which listeners are attached.
  */
 function registerTeamHandlers(socket) {
+  /**
+   * Update the Team model in redis.
+   * Pre-reqs: 'authenticate_team',
+   * Response emits: TODO emit to team info event channel
+   */
   socket.on('update_team', () => {
     teamController.updateTeamInfo(socket, () => {});
+  });
+
+  /**
+   * Adds an Action to the pending actions list for the Team. Updates list in redis.
+   * Pre-reqs: 'authenticate_team',
+   * Response emits: 'selected_actions_update' broadcast to room with a json object
+   *                 whose keys are all Team ids, and values are the id's of the actions
+   *                 they've selected.
+   */
+  socket.on('select_action', (actionId) => {
+    teamController.updatePendingTeamAction(socket, actionId, 'add', () => {});
+  });
+
+  /**
+   * Removes an Action from the pending actions list for the Team. Updates list in redis.
+   * Pre-reqs: 'authenticate_team',
+   * Response emits: 'selected_actions_update' broadcast to room with a json object
+   *                 whose keys are all Team ids, and values are the id's of the actions
+   *                 they've selected.
+   */
+  socket.on('deselect_action', (actionId) => {
+    teamController.updatePendingTeamAction(socket, actionId, 'remove', () => {});
   });
 }
 

--- a/test/tests/app/socket/test-game-controller.js
+++ b/test/tests/app/socket/test-game-controller.js
@@ -1,8 +1,10 @@
 const CONSTANTS = require('../../../data/constants');
 const gameController = require('../../../../app/socket/controllers/game');
 const knex = require('../../../../app/lib/db');
+const redis = require('../../../../app/redis');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+const assert = require('assert');
 
 chai.use(chaiHttp);
 const should = chai.should();
@@ -25,7 +27,10 @@ describe('Game Socket Functions: ', () => {
         gameController.getGameById(1, (game) => {
           game.round_phase.should.equal(0);
           game.current_round.should.equal(1);
-          done();
+          redis.get('game_1_pending_actions').then((pendingActions) => {
+            assert.deepEqual(JSON.parse(pendingActions), {});
+            done();
+          });
         });
       }, CONSTANTS.TIMEOUT);
     });

--- a/test/tests/app/socket/test-team-controller.js
+++ b/test/tests/app/socket/test-team-controller.js
@@ -9,7 +9,7 @@ const redis = require('../../../../app/redis');
 chai.use(chaiHttp);
 const should = chai.should();
 
-describe.only('Team Socket Functions', () => {
+describe('Team Socket Functions', () => {
   before((done) => {
     // Run initial migrations and seed db
     knex.migrate.rollback()

--- a/test/tests/app/socket/test-team-controller.js
+++ b/test/tests/app/socket/test-team-controller.js
@@ -44,10 +44,31 @@ describe.only('Team Socket Functions', () => {
           redis.get('game_1_pending_actions').then((jsonString) => {
             should.exist(jsonString);
             const pendingActions = JSON.parse(jsonString);
-            console.log(pendingActions[1]);
+            pendingActions['2'][0].should.equal(1);
             done();
           });
-        }, 1000);
+        }, CONSTANTS.TIMEOUT);
+      });
+    });
+  });
+
+  it('Should remove pending Team action from redis', (done) => {
+    const socket = getMockSocket();
+    const mockTeamModel = {
+      id: 2,
+      game_id: 1,
+    };
+    redis.set('team_2', JSON.stringify(mockTeamModel));
+    redis.set(socket.id, 2).then(() => {
+      teamController.updatePendingTeamAction(socket, 1, 'remove', () => {
+        setTimeout(() => {
+          redis.get('game_1_pending_actions').then((jsonString) => {
+            should.exist(jsonString);
+            const pendingActions = JSON.parse(jsonString);
+            pendingActions['2'].length.should.equal(0);
+            done();
+          });
+        }, CONSTANTS.TIMEOUT);
       });
     });
   });


### PR DESCRIPTION
Fixes #75 

## Description
This PR adds `select_action` and `deselect_action` event listeners to `Team` sockets. Additionally, an emitter has been created which emits the `selected_actions_update` event to all sockets in the `game_[ID]` room.

Includes the following changes/additions:
* `select_action` and `deselect_action` event listeners attached to authenticated `Team` sockets.
* `selected_actions_update` event emitted to game room when actions update.

## Example Client Emit/Reponse
* Client (team 1): `socket.emit('select_action', 1)`
* Server emits to `game_[ID]` room, where ID is the ID of the Team's game.
```
{
  "1": [1],
  "[TEAM ID]": [ACTION_ID, ACTION_ID, ...],
  ...
}
```
* Client (team 1): `socket.emit('deselect_action', 1)`
* Server emits to `game_[ID]` room, where ID is the ID of the Team's game.
```
{
  "1": [],
  "[TEAM ID]": [ACTION_ID, ACTION_ID, ...],
  ...
}
```

## Known Issues
* pending actions don't reset when incrementing round

## Code coverage for Socket Team Controller
Before | After
------ | ------
42.11% | 82.93%