### PR TITLE
REST API documentation and general cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Andy Meneely
+Copyright (c) 2017 Andy Meneely
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/routes/action.js
+++ b/app/routes/action.js
@@ -4,14 +4,59 @@ const express = require('express');
 
 const router = express.Router();
 
-// GET all Actions
+/**
+ * @api {get} /action Get Actions
+ * @apiName GetActions
+ * @apiGroup Action
+ *
+ * @apiDescription
+ * Retrieve all Actions. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {Action[]}   actions                 List of Actions.
+ * @apiSuccess {Number}     actions.id              Primary key.
+ * @apiSuccess {String}     actions.name            Title of the action.
+ * @apiSuccess {String}     actions.description     A brief explanation of the action.
+ * @apiSuccess {Number}     actions.devcaps_cost    The amount of DevCaps required by a team
+ *                                                  to perform the action.
+ * @apiSuccess {Number}     actions.mindset_reward  The amount of HackerMindset rewarded to a team
+ *                                                  after performing the action.
+ * @apiSuccess {Boolean}    actions.repeatable      Indicates whether or not an action may be
+ *                                                  performed multiple times by a single team.
+ * @apiSuccess {Boolean}    actions.requires_mature Indicates whether or not a team must be Mature
+ *                                                  in order to perform the action.
+ */
 router.get(
   '/',
   authenticationMiddleware.validateAuthentication,
   actionController.getActions
 );
 
-// GET a specific Action
+/**
+ * @api {get} /action/:id Get Action by ID
+ * @apiName GetAction
+ * @apiGroup Action
+ *
+ * @apiDescription
+ * Retrieve an Action by its ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization   Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}     :id             The ID of the action.
+ *
+ * @apiSuccess {Number}     id              Primary key.
+ * @apiSuccess {String}     name            Title of the action.
+ * @apiSuccess {String}     description     A brief explanation of the action.
+ * @apiSuccess {Number}     devcaps_cost    The total number of DevCaps required by a team
+ *                                          to perform the action.
+ * @apiSuccess {Number}     mindset_reward  The total number of HackerMindset rewarded to a team
+ *                                          after performing the action.
+ * @apiSuccess {Boolean}    repeatable      Indicates whether or not an action may be
+ *                                          performed multiple times by a single team.
+ * @apiSuccess {Boolean}    requires_mature Indicates whether or not a team must be Mature
+ *                                          in order to perform the action.
+ */
 router.get(
   '/:id',
   authenticationMiddleware.validateAuthentication,

--- a/app/routes/event.js
+++ b/app/routes/event.js
@@ -4,7 +4,23 @@ const express = require('express');
 
 const router = express.Router();
 
-// GET all events
+/**
+ * @api {get} /event Get Events
+ * @apiName GetEvents
+ * @apiGroup Event
+ *
+ * @apiDescription
+ * Retrieve all Events. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization           Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {Event[]}    events                 List of events.
+ * @apiSuccess {Number}     events.id              Primary key.
+ * @apiSuccess {String}     events.name            Title of the event.
+ * @apiSuccess {String}     events.description     A brief explanation of the event.
+ * @apiSuccess {Number}     events.default_damage  The default amount of company damage inflicted.
+ * @apiSuccess {Boolean}    events.disabled        Indicates whether or not the event is disabled.
+ */
 router.get(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,
@@ -12,7 +28,25 @@ router.get(
   eventController.getEvents
 );
 
-// GET a specific event
+/**
+ * @api {get} /event/:id Get Event by ID
+ * @apiName GetEvent
+ * @apiGroup Event
+ *
+ * @apiDescription
+ * Retrieve an Event by its ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}     :id                    The ID of the Event to retrieve.
+ *
+ * @apiSuccess {Event[]}    events                 List of events.
+ * @apiSuccess {Number}     events.id              Primary key.
+ * @apiSuccess {String}     events.name            Title of the event.
+ * @apiSuccess {String}     events.description     A brief explanation of the event.
+ * @apiSuccess {Number}     events.default_damage  The default amount of company damage inflicted.
+ * @apiSuccess {Boolean}    events.disabled        Indicates whether or not the event is disabled.
+ */
 router.get(
   '/:id',
   authenticationMiddleware.validateAuthenticationAttachEntity,
@@ -20,7 +54,28 @@ router.get(
   eventController.getEventById
 );
 
-// CREATE a new user
+/**
+ * @api {post} /event Create new Event
+ * @apiName CreateEvent
+ * @apiGroup Event
+ *
+ * @apiDescription
+ * Create a new Event. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {String}  name            Title of the new event.
+ * @apiParam   {String}  description     A brief explanation of the new event.
+ * @apiParam   {Number}  default_damage  The default amount of company damage inflicted.
+ * @apiParam   {Boolean} [disabled]      Optional. Indicates whether or not the event is disabled.
+ *                                         Defaults to 'false'.
+ *
+ * @apiSuccess {Number}  id              Primary key.
+ * @apiSuccess {String}  name            Title of the event.
+ * @apiSuccess {String}  description     A brief explanation of the event.
+ * @apiSuccess {Number}  default_damage  The default amount of company damage inflicted.
+ * @apiSuccess {Boolean} disabled        Indicates whether or not the event is disabled.
+ */
 router.post(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,
@@ -28,7 +83,28 @@ router.post(
   eventController.createEvent
 );
 
-// UPDATE a specific event
+/**
+ * @api {patch} /event/:id Modify Event by ID
+ * @apiName EditEvent
+ * @apiGroup Event
+ *
+ * @apiDescription
+ * Modify an existing Event. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}  :id               The ID of the Event to be modified.
+ * @apiParam   {String}  [name]            Title of the event.
+ * @apiParam   {String}  [description]     A brief explanation of the event.
+ * @apiParam   {Number}  [default_damage]  The default amount of company damage inflicted.
+ * @apiParam   {Boolean} [disabled]        Indicates whether or not the event is disabled.
+ *
+ * @apiSuccess {Number}  id              Primary key.
+ * @apiSuccess {String}  name            Title of the event.
+ * @apiSuccess {String}  description     A brief explanation of the event.
+ * @apiSuccess {Number}  default_damage  The default amount of company damage inflicted.
+ * @apiSuccess {Boolean} disabled        Indicates whether or not the event is disabled.
+ */
 router.patch(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,

--- a/app/routes/game.js
+++ b/app/routes/game.js
@@ -5,7 +5,7 @@ const express = require('express');
 const router = express.Router();
 
 /**
- * @api {get} /game Get All Games
+ * @api {get} /game Get Games
  * @apiName GetGames
  * @apiGroup Game
  *
@@ -19,20 +19,20 @@ const router = express.Router();
  *                                              Valid options include: 'storyteller' and 'teams'.
  *                                              One relation per 'withRelated' query param.
  *
- * @apiParam   {Integer}    [storyteller_id]  Filter Games matching the storyteller_id.
+ * @apiParam   {Number}     [storyteller_id]  Filter Games matching the storyteller_id.
  *
  * @apiSuccess {Game[]}     games                 List of Games.
- * @apiSuccess {Integer}    games.id              Primary key of the Game.
+ * @apiSuccess {Number}     games.id              Primary key of the Game.
  * @apiSuccess {String}     games.name            Custom name of the Game.
  * @apiSuccess {String}     games.created_at      ISO String timestamp of when the Game was created.
- * @apiSuccess {Integer}    games.current_round   The current round of the Game.
- * @apiSuccess {Integer}    games.max_round       The round at which the Game will end.
- * @apiSuccess {Integer}    games.round_phase     The current round phase the Game is in.
+ * @apiSuccess {Number}     games.current_round   The current round of the Game.
+ * @apiSuccess {Number}     games.max_round       The round at which the Game will end.
+ * @apiSuccess {Number}     games.round_phase     The current round phase the Game is in.
  *                                                  Dictates what actions can take place.
- * @apiSuccess {Integer}    games.storyteller_id  The foreign key reference to the
+ * @apiSuccess {Number}     games.storyteller_id  The foreign key reference to the
  *                                                  Professor User running the Game session.
  * @apiSuccess {User}       [games.storyteller]   The User object representing the Storyteller.
- *                                                  Only returned when 'withRelated' == 'storyteller'.
+ *                                                  Only returned when 'withRelated'=='storyteller'.
  */
 router.get(
   '/',
@@ -40,7 +40,21 @@ router.get(
   gameController.getGames
 );
 
-// CREATE a new Game
+/**
+ * @api {post} /game Create Game
+ * @apiName CreateGame
+ * @apiGroup Game
+ *
+ * @apiDescription
+ * Create a new Game. Requires authentication.
+ *
+ * @apiHeader  {String}   Authorization     Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {String}   name              The name for the game; Unique.
+ * @apiParam   {Number}   max_round         The number of rounds the game will last.
+ * @apiParam   {Number}   [storyteller_id]  Optional. The ID of a User in the 'professor' role.
+ *                                          Defaults to the User issuing the request.
+ */
 router.post(
   '/',
   authMiddleware.validateAuthenticationAttachEntity,
@@ -49,7 +63,7 @@ router.post(
 );
 
 /**
- * @api {get} /game Get Game by ID
+ * @api {get} /game/:id Get Game by ID
  * @apiName GetGame
  * @apiGroup Game
  *
@@ -58,22 +72,24 @@ router.post(
  *
  * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
  *
- * @apiParam   {String}     [withRelated]     Specify which relations
+ * @apiParam   {Number}     :id               The ID of the game.
+ *
+ * @apiParam   {String}     [withRelated]     Query param. Specify which relations
  *                                              the Games should be returned with.
  *                                              Valid options include: 'storyteller' and 'teams'.
  *                                              One relation per 'withRelated' query param.
  *
- * @apiSuccess {Integer}    id                Primary key.
+ * @apiSuccess {Number}     id                Primary key.
  * @apiSuccess {String}     name              Custom name of the Game.
  * @apiSuccess {String}     created_at        ISO String timestamp of when the Game was created.
- * @apiSuccess {Integer}    current_round     The current round of the Game
- * @apiSuccess {Integer}    max_round         The round at which the Game will end.
- * @apiSuccess {Integer}    round_phase       The current round phase the Game is in.
- *                                              Dictates what actions can take place.
- * @apiSuccess {Integer}    storyteller_id    The foreign key reference to the
+ * @apiSuccess {Number}     current_round     The current round of the Game.
+ * @apiSuccess {Number}     max_round         The round at which the Game will end.
+ * @apiSuccess {Number}     round_phase       The current round phase the Game is in.
+ *                                              Dictates what actions/events are taking place.
+ * @apiSuccess {Number}     storyteller_id    The foreign key reference to the
  *                                              Professor user running the Game session.
  * @apiSuccess {User}       [storyteller]     The User object representing the Storyteller.
- *                                              Only returned when 'withRelated' == 'storyteller'.
+ *                                              Only returned when 'withRelated'=='storyteller'.
  */
 router.get(
   '/:id',
@@ -81,7 +97,26 @@ router.get(
   gameController.getGameById
 );
 
-// PATCH Game by id
+/**
+ * @api {patch} /game/:id Modify Game by ID
+ * @apiName EditGame
+ * @apiGroup Game
+ *
+ * @apiDescription
+ * Modify an existing Game. Requires authentication.
+ *
+ * @apiHeader  {String}   Authorization       Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}   :id                 The ID of the Game to be modified.
+ *
+ * @apiParam   {String}   [name]              The name for the game; Unique.
+ * @apiParam   {Number}   [max_round]         The number of rounds the game will last.
+ * @apiParam   {Number}   [storyteller_id]    Optional. The ID of a User in the 'professor' role.
+ *                                              Defaults to the User issuing the request.
+ * @apiParam   {Number}   [current_round]     The current round of the Game.
+ * @apiParam   {Number}   [round_phase]       The currend round phase the game is in.
+ *                                              Dictates what actions/events are taking place.
+ */
 router.patch(
   '/:id',
   authMiddleware.validateAuthenticationAttachEntity,

--- a/app/routes/role.js
+++ b/app/routes/role.js
@@ -3,10 +3,52 @@ const express = require('express');
 
 const router = express.Router();
 
-// GET a person
+/**
+ * @api {get} /role Get Roles
+ * @apiName GetRoles
+ * @apiGroup Role
+ *
+ * @apiDescription
+ * Retrieve all user Roles.
+ *
+ * @apiSuccess {Object[]}   roles       List of Roles.
+ * @apiSuccess {Number}     roles.id    Primary key.
+ * @apiSuccess {String}     roles.name  Name of the role; Unique.
+ */
 router.get('/', roleController.getRoles);
-router.post('/', roleController.createRole);
+
+/**
+ * @api {get} /role/:id/users Get Users by Role
+ * @apiName GetRoleUsers
+ * @apiGroup Role
+ *
+ * @apiDescription
+ * Retrieve all Users in a given Role
+ *
+ * @apiParam   {Number}     id          The ID of the Role to filter by.
+ *
+ * @apiSuccess {Object[]}   users             List of Users.
+ * @apiSuccess {Number}     users.id          Primary key.
+ * @apiSuccess {String}     users.username    Username; unique.
+ * @apiSuccess {Boolean}    users.is_admin    Indicates whether or not the User is an Administrator.
+ * @apiSuccess {String}     users.created_at  ISO String timestamp of when the User was created.
+ */
 router.get('/:id/users', roleController.getRoleUsers);
+
+/**
+ * @api {post} /role Create a Role
+ * @apiName CreateRole
+ * @apiGroup Role
+ *
+ * @apiDescription
+ * Create a new user Role.
+ *
+ * @apiParam   {String}     name  Name of the new role.
+ *
+ * @apiSuccess {Number}     id    Primary key.
+ * @apiSuccess {String}     name  Name of the role; Unique.
+ */
+router.post('/', roleController.createRole);
 
 /**
  * Generate 404s.

--- a/app/routes/rumor.js
+++ b/app/routes/rumor.js
@@ -4,23 +4,106 @@ const express = require('express');
 
 const router = express.Router();
 
+// all routes require authentication middleware
 router.use(
   authenticationMiddleware.validateAuthenticationAttachEntity
 );
 
+/**
+ * @api {get} /rumor Get Rumors
+ * @apiName GetRumors
+ * @apiGroup Rumor
+ *
+ * @apiDescription
+ * Retrieve all Rumors. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {Rumor[]}    rumors                 List of rumors.
+ * @apiSuccess {Number}     rumors.id              Primary key.
+ * @apiSuccess {String}     rumors.name            Title of the rumor.
+ * @apiSuccess {String}     rumors.description     A brief explanation of the rumor.
+ * @apiSuccess {Number}     rumors.event_id        The Event ID with which the rumor is associated.
+ * @apiSuccess {Boolean}    rumors.disabled        Indicates whether or not the rumor is disabled.
+ */
 router.get(
   '/',
   rumorControlller.getRumors
 );
+
+/**
+ * @api {get} /rumor/:id Get Rumor by ID
+ * @apiName GetRumor
+ * @apiGroup Rumor
+ *
+ * @apiDescription
+ * Retrieve a Rumor given its ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}     :id                    ID of the Rumor to retrieve.
+ *
+ * @apiSuccess {Number}     id              Primary key.
+ * @apiSuccess {String}     name            Title of the rumor.
+ * @apiSuccess {String}     description     A brief explanation of the rumor.
+ * @apiSuccess {Number}     event_id        The Event ID with which the rumor is associated.
+ * @apiSuccess {Boolean}    disabled        Indicates whether or not the rumor is disabled.
+ */
+router.get(
+  '/:id',
+  rumorControlller.getRumorById
+);
+
+/**
+ * @api {post} /rumor Create Rumor
+ * @apiName CreateRumor
+ * @apiGroup Rumor
+ *
+ * @apiDescription
+ * Create a new Rumor. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam {String}     name         Title of the new rumor.
+ * @apiParam {String}     description  A brief explanation of the new rumor.
+ * @apiParam {Number}     event_id     The Event ID with which the new rumor is associated.
+ * @apiParam {Boolean}    [disabled]   Optional. Indicates whether or not the new rumor is disabled.
+ *
+ * @apiSuccess {Number}   id           Primary key.
+ * @apiSuccess {String}   name         Title of the rumor.
+ * @apiSuccess {String}   description  A brief explanation of the rumor.
+ * @apiSuccess {Number}   event_id     The Event ID with which the rumor is associated.
+ * @apiSuccess {Boolean}  disabled     Indicates whether or not the rumor is disabled.
+ */
 router.post(
   '/',
   authenticationMiddleware.verifyProfessor,
   rumorControlller.createRumor
 );
-router.get(
-  '/:id',
-  rumorControlller.getRumorById
-);
+
+/**
+ * @api {post} /rumor/:id Modify Rumor by ID
+ * @apiName CreateRumor
+ * @apiGroup Rumor
+ *
+ * @apiDescription
+ * Modify an existing Rumor given its ID. Requires authentication.
+ *
+ * @apiHeader  {String}     Authorization          Bearer [JWT_TOKEN]
+ *
+ * @apiParam {Number}     :id            The ID of the Rumor to be modified.
+ *
+ * @apiParam {String}     [name]         Title of the new rumor.
+ * @apiParam {String}     [description]  A brief explanation of the new rumor.
+ * @apiParam {Number}     [event_id]     The Event ID with which the new rumor is associated.
+ * @apiParam {Boolean}    [disabled]     Indicates whether or not the new rumor is disabled.
+ *
+ * @apiSuccess {Number}     id           Primary key.
+ * @apiSuccess {String}     name         Title of the rumor.
+ * @apiSuccess {String}     description  A brief explanation of the rumor.
+ * @apiSuccess {Number}     event_id     The Event ID with which the rumor is associated.
+ * @apiSuccess {Boolean}    disabled     Indicates whether or not the rumor is disabled.
+ */
 router.patch(
   '/:id',
   authenticationMiddleware.verifyProfessor,

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -5,23 +5,81 @@ const express = require('express');
 
 const router = express.Router();
 
-// Optional: include a query param 'game_id' to return Teams for a specific game.
+/**
+ * @api {get} /team Get Teams
+ * @apiName GetTeams
+ * @apiGroup Team
+ *
+ * @apiDescription
+ * Retrieve all Teams.
+ *
+ * @apiParam   {String}   [game_id]           Query param to return teams for a specified game.
+ *
+ * @apiSuccess {Team[]}   teams               List of teams.
+ * @apiSuccess {Number}   teams.id            Primary key.
+ * @apiSuccess {String}   teams.name          The custom name for the team.
+ * @apiSuccess {Boolean}  teams.mature        Indicates whether or not the team is 'mature'.
+ * @apiSuccess {Number}   teams.resources     The amount of resources the team has to spend.
+ * @apiSuccess {Number}   teams.mindset       The amount of hacker mindset the team has earned.
+ * @apiSuccess {Number}   teams.teamtype_id   ID of the TeamType with which the team is associated.
+ * @apiSuccess {Number}   teams.game_id       ID of the Game with which the team is associated.
+ * @apiSuccess {String}   teams.link_code     Random alphanumeric string used to auth with the API.
+ */
 router.get(
   '/',
   teamController.getTeams
 );
 
+/**
+ * @api {get} /team/:id Get Team by ID
+ * @apiName GetTeam
+ * @apiGroup Team
+ *
+ * @apiDescription
+ * Retrieve Team by its ID.
+ *
+ * @apiParam   {String}   :id           The ID of the team to retrieve.
+ *
+ * @apiSuccess {Number}   id            Primary key.
+ * @apiSuccess {String}   name          The custom name for the team.
+ * @apiSuccess {Boolean}  mature        Indicates whether or not the team is 'mature'.
+ * @apiSuccess {Number}   resources     The amount of resources the team has to spend.
+ * @apiSuccess {Number}   mindset       The amount of hacker mindset the team has earned.
+ * @apiSuccess {Number}   teamtype_id   ID of the TeamType with which the team is associated.
+ * @apiSuccess {Number}   game_id       ID of the Game with which the team is associated.
+ * @apiSuccess {String}   link_code     Random alphanumeric string used to auth with the API.
+ */
 router.get(
   '/:id',
   teamController.getTeamById
 );
 
-router.patch(
-  '/:id',
-  authenticationMiddleware.validateAuthenticationAttachEntity,
-  teamController.updateExistingTeam
-);
-
+/**
+ * @api {post} /team Create a Team
+ * @apiName CreateTeam
+ * @apiGroup Team
+ *
+ * @apiDescription
+ * Create a new Team. Requires authentication.
+ *
+ * @apiHeader {String}   Authorization   Bearer [JWT_TOKEN]
+ *
+ * @apiParam {Number}    teamtype_id     ID of the TeamType with which the team is associated.
+ * @apiParam {Number}    game_id         ID of the Game with which the team is associated.
+ * @apiParam {String}    [name]          The custom name for the team.
+ * @apiParam {Boolean}   [mature]        Indicates whether or not the team is 'mature'.
+ * @apiParam {Number}    [resources]     The amount of resources the team has to spend.
+ * @apiParam {Number}    [mindset]       The amount of hacker mindset the team has earned.
+ *
+ * @apiSuccess {Number}   id             Primary key.
+ * @apiSuccess {String}   name           The custom name for the team.
+ * @apiSuccess {Boolean}  mature         Indicates whether or not the team is 'mature'.
+ * @apiSuccess {Number}   resources      The amount of resources the team has to spend.
+ * @apiSuccess {Number}   mindset        The amount of hacker mindset the team has earned.
+ * @apiSuccess {Number}   teamtype_id    ID of the TeamType with which the team is associated.
+ * @apiSuccess {Number}   game_id        ID of the Game with which the team is associated.
+ * @apiSuccess {String}   link_code      Random alphanumeric string used to auth with the API.
+ */
 router.post(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,
@@ -29,12 +87,52 @@ router.post(
   teamController.createTeam
 );
 
+/**
+ * @api {patch} /team/:id Modify Team by ID
+ * @apiName EditTeam
+ * @apiGroup Team
+ *
+ * @apiDescription
+ * Modify a Team given its ID. Currently only supports Teams updating their 'name' field.
+ * Requires Team authentication.
+ *
+ * @apiHeader  {String}   Authorization Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {String}   :id           The ID of the team to modify.
+ * @apiParam   {String}   name          The custom name for the team; Unique.
+ *
+ * @apiSuccess {Number}   id            Primary key.
+ * @apiSuccess {String}   name          The custom name for the team. Defaults to TeamType name.
+ * @apiSuccess {Boolean}  mature        Indicates whether or not the team is 'mature'.
+ * @apiSuccess {Number}   resources     The amount of resources the team has to spend.
+ * @apiSuccess {Number}   mindset       The amount of hacker mindset the team has earned.
+ * @apiSuccess {Number}   teamtype_id   ID of the TeamType with which the team is associated.
+ * @apiSuccess {Number}   game_id       ID of the Game with which the team is associated.
+ * @apiSuccess {String}   link_code     Random alphanumeric string used to auth with the API.
+ */
+router.patch(
+  '/:id',
+  authenticationMiddleware.validateAuthenticationAttachEntity,
+  teamController.updateExistingTeam
+);
+
+/**
+ * @api {post} /team/login Modify Team by ID
+ * @apiName LoginTeam
+ * @apiGroup Team
+ *
+ * @apiDescription
+ * Authenticate a Team given a valid link_code.
+ *
+ * @apiParam   {String}  link   The link_code of an existing Team.
+ *
+ * @apiSuccess {String}  token  The new JWT Token.
+ */
 router.post(
   '/login',
   authenticationMiddleware.validateTeamAttachTeam,
   authController.refreshToken
 );
-
 
 /**
  * Generate 404s.

--- a/app/routes/teamtype.js
+++ b/app/routes/teamtype.js
@@ -4,27 +4,118 @@ const express = require('express');
 
 const router = express.Router();
 
+/**
+ * @api {get} /teamtype Get TeamTypes
+ * @apiName GetTeamTypes
+ * @apiGroup TeamType
+ *
+ * @apiDescription
+ * Retrieve all TeamTypes. Requires authentication.
+ *
+ * @apiHeader  {String}      Authorization                Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {TeamType[]}  teamtypes                    List of teamtypes.
+ * @apiSuccess {Number}      teamtypes.id                 Primary key.
+ * @apiSuccess {String}      teamtypes.name               The name of the teamtype.
+ * @apiSuccess {Boolean}     teamtypes.initial_mature     The default 'mature' value for Teams
+ *                                                          created from this teamtype.
+ * @apiSuccess {Number}      teamtypes.initial_resources  The default amount of resources a Team
+ *                                                          of this type has to spend.
+ * @apiSuccess {Number}      teamtypes.initial_mindset    The default amount of hacker mindset a
+ *                                                          Team of this type has earned.
+ **/
 router.get(
   '/',
   authenticationMiddleware.validateAuthentication,
   teamtypeController.getTeamTypes
 );
+
+/**
+ * @api {get} /teamtype/:id Get TeamType by ID
+ * @apiName GetTeamType
+ * @apiGroup TeamType
+ *
+ * @apiDescription
+ * Retrieve a TeamType by its ID. Requires authentication.
+ *
+ * @apiHeader  {String}      Authorization      Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}      :id                The ID of the teamtype to retrieve.
+ *
+ * @apiSuccess {Number}      id                 Primary key.
+ * @apiSuccess {String}      name               The name of the teamtype.
+ * @apiSuccess {Boolean}     initial_mature     The default 'mature' value for Teams
+ *                                                          created from this teamtype.
+ * @apiSuccess {Number}      initial_resources  The default amount of resources a Team
+ *                                                          of this type has to spend.
+ * @apiSuccess {Number}      initial_mindset    The default amount of hacker mindset a
+ *                                                          Team of this type has earned.
+ **/
 router.get(
   '/:id',
   authenticationMiddleware.validateAuthentication,
   teamtypeController.getTeamTypeById
 );
-router.patch(
-  '/:id',
-  authenticationMiddleware.validateAuthenticationAttachEntity,
-  authenticationMiddleware.verifyProfessor,
-  teamtypeController.updateExistingTeamType
-);
+
+/**
+ * @api {post} /teamtype Create new TeamType
+ * @apiName CreateTeamType
+ * @apiGroup TeamType
+ *
+ * @apiDescription
+ * Create a new TeamType. Requires authentication.
+ *
+ * @apiHeader  {String}      Authorization      Bearer [JWT_TOKEN]
+ *
+ * @apiSuccess {Number}      id                 Primary key.
+ * @apiSuccess {String}      name               The name of the teamtype.
+ * @apiSuccess {Boolean}     initial_mature     The default 'mature' value for Teams
+ *                                                          created from this teamtype.
+ * @apiSuccess {Number}      initial_resources  The default amount of resources a Team
+ *                                                          of this type has to spend.
+ * @apiSuccess {Number}      initial_mindset    The default amount of hacker mindset a
+ *                                                          Team of this type has earned.
+ **/
 router.post(
   '/',
   authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationMiddleware.verifyProfessor,
   teamtypeController.createTeamType
+);
+
+/**
+ * @api {patch} /teamtype/:id Modify TeamType by ID
+ * @apiName EditTeamType
+ * @apiGroup TeamType
+ *
+ * @apiDescription
+ * Modify a TeamType given its ID. Requires authentication.
+ *
+ * @apiHeader  {String}      Authorization        Bearer [JWT_TOKEN]
+ *
+ * @apiParam   {Number}      :id                  The ID of the teamtype to be modified.
+ * @apiParam   {String}      [name]               The name of the teamtype.
+ * @apiParam   {Boolean}     [initial_mature]     The default 'mature' value for Teams
+ *                                                  created from this teamtype.
+ * @apiParam   {Number}      [initial_resources]  The default amount of resources a Team
+ *                                                  of this type has to spend.
+ * @apiParam   {Number}      [initial_mindset]    The default amount of hacker mindset a
+ *                                                  Team of this type has earned.
+ *
+ * @apiSuccess {Number}      id                 Primary key.
+ * @apiSuccess {String}      name               The name of the teamtype.
+ * @apiSuccess {Boolean}     initial_mature     The default 'mature' value for Teams
+ *                                                created from this teamtype.
+ * @apiSuccess {Number}      initial_resources  The default amount of resources a Team
+ *                                                of this type has to spend.
+ * @apiSuccess {Number}      initial_mindset    The default amount of hacker mindset a
+ *                                                Team of this type has earned.
+ **/
+router.patch(
+  '/:id',
+  authenticationMiddleware.validateAuthenticationAttachEntity,
+  authenticationMiddleware.verifyProfessor,
+  teamtypeController.updateExistingTeamType
 );
 
 /**

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -37,7 +37,7 @@ router.get(
  *
  * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
  *
- * @apiParam   {Number}     id          User's primary key
+ * @apiParam   {Number}     :id         User's primary key
  *
  * @apiSuccess {Number}     id          Primary key.
  * @apiSuccess {String}     username    Username; unique.
@@ -65,7 +65,7 @@ router.get(
  * @apiParam {String}   email       Unique email address of the User.
  * @apiParam {Boolean}  [is_admin]  Set `true` for Admin account.
  *
- * @apiSuccess {Integer}  id        Primary key of the new User.
+ * @apiSuccess {Number}   id        Primary key of the new User.
  * @apiSuccess {String}   username  Username of the new User.
  */
 router.post(
@@ -75,10 +75,22 @@ router.post(
   userController.registerNewUser
 );
 
-// DELETE a user
+/**
+ * @api {delete} /user/:id Delete User by ID
+ * @apiName DeleteUser
+ * @apiGroup User
+ *
+ * @apiDescription
+ * Delete an existing User. Requires administrator authentication.
+ *
+ * @apiHeader {String}  Authorization  Bearer [JWT_TOKEN]
+ *
+ * @apiParam  {String}  :id            ID of the User to be deleted.
+ */
 router.delete(
   '/:id',
-  authenticationMiddleware.validateAuthentication,  // isAuthenticated middleware
+  authenticationMiddleware.validateAuthenticationAttachEntity,
+  authenticationMiddleware.verifyAdministrator,
   userController.deleteUserById
 );
 
@@ -93,13 +105,13 @@ router.delete(
  * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
  *
  * @apiParam {String}   :id         Primary key for the existing User.
- * @apiParam {Integer}  [add]       The Role ID to add the User to.
- * @apiParam {Integer}  [remove]    The Role ID to remove the User from.
+ * @apiParam {Number}   [add]       The Role ID to add the User to.
+ * @apiParam {Number}   [remove]    The Role ID to remove the User from.
  */
 router.patch(
   '/:id/roles',
-  authenticationMiddleware.validateAuthenticationAttachEntity, // verify token and attach user to res
-  authenticationMiddleware.verifyAdministrator,              // verifyAdministrator middleware
+  authenticationMiddleware.validateAuthenticationAttachEntity,
+  authenticationMiddleware.verifyAdministrator,
   userController.setRoles
 );
 
@@ -129,16 +141,16 @@ router.post(
  * @apiDescription
  * Refresh the JWT token of the User making the request. Requires authentication.
  *
- * @apiHeader  {String}     Authorization     Bearer [JWT_TOKEN]
+ * @apiHeader  {String}     Authorization   Bearer [JWT_TOKEN]
  *
- * @apiSuccess {String}     token             A new JWT token with which to send authenticated requests.
+ * @apiSuccess {String}     token           A new JWT token with which
+ *                                          to send authenticated requests.
  */
 router.post(
   '/refresh',
   authenticationMiddleware.validateAuthenticationAttachEntity,
   authenticationController.refreshToken
 );
-
 
 /**
  * Generate 404s.

--- a/knexfile.js
+++ b/knexfile.js
@@ -3,22 +3,22 @@
 module.exports = {
 
   development: {
-    // client: 'postgresql',
-    client: 'sqlite3',
+    client: 'postgresql',
+    // client: 'sqlite3',
     connection: {
-      // database: 'fortress_dev',
-      // user: 'postgres',
-      // password: 'password',
-      filename: './database.sqlite3',
+      database: 'fortress_dev',
+      user: 'development',
+      password: 'password',
+      // filename: './database.sqlite3',
     },
     // required for sqlite
-    useNullAsDefault: true,
+    // useNullAsDefault: true,
 
     // only use with postgresql
-    // pool: {
-    //   min: 2,
-    //   max: 10,
-    // },
+    pool: {
+      min: 2,
+      max: 10,
+    },
     seeds: {
       directory: './seeds/knex',
     },
@@ -41,7 +41,7 @@ module.exports = {
   staging: {
     client: 'postgresql',
     connection: {
-      database: 'my_db',
+      database: 'fortress_stage',
       user: 'username',
       password: 'password',
     },
@@ -57,7 +57,7 @@ module.exports = {
   production: {
     client: 'postgresql',
     connection: {
-      database: 'my_db',
+      database: 'fortress_prod',
       user: 'username',
       password: 'password',
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The API for the Dev-Fortress security game.",
   "private": true,
   "scripts": {
-    "start": "DEBUG=* NODE_ENV=development node ./bin/www",
+    "start": "NODE_ENV=development node ./bin/www",
     "test": "NODE_ENV=test nyc _mocha test/tests/**/*",
     "docs": "jsdoc -c ./jsdoc.json -r",
     "coverage": "NODE_ENV=test nyc --reporter=html _mocha test/tests/**/*",
@@ -35,6 +35,7 @@
     "jsonwebtoken": "^7.1.9",
     "knex": "^0.11.10",
     "morgan": "~1.7.0",
+    "pg": "^6.2.3",
     "randomstring": "^1.1.5",
     "redis-server": "^1.1.0",
     "serve-favicon": "~2.3.0",

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,8 +1,0 @@
-body {
-  padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
-}
-
-a {
-  color: #00B7FF;
-}


### PR DESCRIPTION
# Description
This pull request completes documentation of existing API endpoints and changes the default development database from `sqlite` to `postgresql`. Additionally, some unused project files were removed.

Includes the following changes/additions:
* `LICENSE.md` copyright updated to 2017
* `knexfile` updated with `postgres` configurations.
* All `app/routes/*` API route functions decorated with `ApiDocs` documentation.
* `public/*` directory and subfolders removed as they were not being used.

To update and view the documentation locally, perform these commands at the root of the project directory:
* `npm run apidocs` - updates the generated documentation
* `open ./doc/index.html` - opens the documentation website in default browser on macOS