### PR TITLE
Storyteller can get/update their queue of rumors

### DIFF
--- a/app/socket/controllers/game.js
+++ b/app/socket/controllers/game.js
@@ -75,10 +75,36 @@ function startGame(gameId, callback) {
   });
 }
 
+/**
+ * Retrieve the rumor queue array for a specific game.
+ * @param {Number} gameId the ID of the game for the rumor queue
+ * @param {Function} callback the callback function to pass the rumor queue array to
+ */
+function getRumorQueue(gameId, callback) {
+  redis.get(`game_${gameId}_rumor_queue`, (err, rumorQueueString) => {
+    if (rumorQueueString !== null) callback(JSON.parse(rumorQueueString));
+    else callback([]);
+  });
+}
+
+/**
+ * Update the rumor queue for a specific game.
+ * @param {Number} gameId the ID of the Game for the rumor queue
+ * @param {Number[]} rumorQueue collection of rumor IDs
+ * @param {Function} callback the callback function after execution is complete
+ */
+function updateRumorQueue(socket, gameId, rumorQueue, callback) {
+  redis.set(`game_${gameId}_rumor_queue`, JSON.stringify(rumorQueue));
+  emitters.storytellerEmitters.emitRumorQueueUpdate(socket, gameId, rumorQueue);
+  callback();
+}
+
 module.exports = {
   updateGameInfo,
   getGamesByStorytellerId,
   getGameById,
   startGame,
   nextRound,
+  getRumorQueue,
+  updateRumorQueue,
 };

--- a/app/socket/emitters/game.js
+++ b/app/socket/emitters/game.js
@@ -11,6 +11,11 @@ function emitGameUpdate(game) {
   generalEmitters.emitToRoom(`game_${game.id}`, 'game_info', game);
 }
 
+/**
+ * Emit pending action selections.
+ * @param {Integer} gameId the ID of the Game
+ * @param {JSON} pendingActions keys: team IDs; values: arrays of Action ID's
+ */
 function emitPendingActionsUpdate(gameId, pendingActions) {
   generalEmitters.emitToRoom(`game_${gameId}`, 'selected_actions_update', pendingActions);
 }

--- a/app/socket/emitters/storyteller.js
+++ b/app/socket/emitters/storyteller.js
@@ -12,6 +12,20 @@ function emitStorytellerGames(socket, gamesList) {
   generalEmitters.emitToSocket(socket, 'games_list', gamesList);
 }
 
+/**
+ * Emit rumor queue updates to the requesting Socket.
+ * @param {Socket.io} socket the Storyteller socket to emit to.
+ * @param {Integer} gameId the ID of the Game
+ * @param {JSON} rumorQueue keys: game_id, rumor_queue
+ */
+function emitRumorQueueUpdate(socket, gameId, rumorQueue) {
+  const rumorQueueJson = {};
+  rumorQueueJson.game_id = gameId;
+  rumorQueueJson.rumor_queue = rumorQueue;
+  generalEmitters.emitToSocket(socket, 'rumor_queue', rumorQueueJson);
+}
+
 module.exports = {
   emitStorytellerGames,
+  emitRumorQueueUpdate,
 };

--- a/socket-events.md
+++ b/socket-events.md
@@ -12,6 +12,8 @@ Event Name | Event Data | Description
 `update_games_list` | _None_ | Force update of redis cache with Storyteller's games from DB. Server emits `games_list` event with updated data.
 `select_action` | `ACTION_ID` | Add an action to the pending actions list for the Team.
 `deselect_action` | `ACTION_ID` | Remove an action from the pending actions list for the Team.
+`update_rumor_queue` | `{ "game_id": GAME_ID, "rumor_queue": [RUMOR_ID, ...] }` | Client emits the entire collection any time the Storyteller updates the `RumorQueue`. Server should store this in redis.
+`get_rumor_queue` | `GAME_ID` | Force the Server to emit the `RumorQueue`. Clients may use this if they lose connection / state.
 
 ## Server Emits
 Event Name | Event Data | Description
@@ -19,3 +21,4 @@ Event Name | Event Data | Description
 `info` | `{ "event": "EVENT_NAME", "message": "HUMAN_READABLE_MESSAGE", "didSucceed": BOOLEAN }` | Emitted privately to the requesting socket after their request has been completed. Client may use this for debugging as well as to trigger additional events based on the value of `didSucceed`.
 `game_info` | JSON representation of `Game` model with related `teams` and `storyteller` data... _See API docs_ | Broadcasted to the relevant Game room whenever game state changes and when a `Team` or `Storyteller` client joins. Clients should use this to manage their Game and Team state/views.
 `selected_actions_update` | `{ TEAM_ID: [ACTION_ID, ...], ... }` | Used to maintain the state of Team selections during the Action Selection phase. All Clients should use this to maintain state/update their views as needed.
+`rumor_queue` | `{ "game_id": GAME_ID, "rumor_queue": [RUMOR_ID, ...] }` | Server emits the `RumorQueue` anytime it is updated, or in response to the `get_rumor_queue` event.


### PR DESCRIPTION
Addresses #85 

This pull request adds support for a Storyteller queue of Rumors they can maintain. See `socket-events.md` for event documentation.